### PR TITLE
New and improved BitVector implementation

### DIFF
--- a/src/main/scala/scodec/BitVector.scala
+++ b/src/main/scala/scodec/BitVector.scala
@@ -1,11 +1,9 @@
 package scodec
 
-import scala.collection.IndexedSeqOptimized
-import scala.collection.mutable.Builder
-import scalaz.{\/, Monoid}
-
 import java.nio.ByteBuffer
-
+import scala.collection.immutable.BitSet
+import scalaz.\/
+import scalaz.\/.{left,right}
 
 /**
  * Persistent vector of bits, stored as bytes.
@@ -24,36 +22,8 @@ import java.nio.ByteBuffer
  * @groupname conversions Conversions
  * @groupprio conversions 3
  */
-trait BitVector extends IndexedSeqOptimized[Boolean, BitVector] with BitwiseOperations[BitVector] {
-
-  /**
-   * Returns true if this bit vector has no bits.
-   *
-   * @group collection
-   */
-  def isEmpty: Boolean
-
-  /**
-   * Returns true if this bit vector has a non-zero number of bits.
-   *
-   * @group collection
-   */
-  def nonEmpty: Boolean
-
-  /**
-   * Returns number of bits in this vector.
-   *
-   * @group collection
-   */
-  def size: Int
-
-  /**
-   * Alias for `get`.
-   *
-   * @group individual
-   * @see get(Int)
-   */
-  final def apply(n: Int): Boolean = get(n)
+sealed trait BitVector {
+  import BitVector._
 
   /**
    * Returns true if the `n`th bit is high, false otherwise.
@@ -62,42 +32,169 @@ trait BitVector extends IndexedSeqOptimized[Boolean, BitVector] with BitwiseOper
    *
    * @group individual
    */
-  def get(n: Int): Boolean
-
-  /**
-   * Returns `Some(true)` if the `n`th bit is high, `Some(false)` if low, and `None` if `n >= size`.
-   *
-   * @group individual
-   */
-  def lift(n: Int): Option[Boolean]
+  def get(n: Long): Boolean
 
   /**
    * Returns a new bit vector with the `n`th bit high if `high` is true or low if `high` is false.
    *
    * @group individual
    */
-  def updated(n: Int, high: Boolean): BitVector
+  def updated(n: Long, high: Boolean): BitVector
 
   /**
-   * Returns a new bit vector with the `n`th bit high (and all other bits unmodified).
+   * Returns number of bits in this vector.
    *
-   * @group individual
+   * @group collection
    */
-  final def set(n: Int): BitVector = updated(n, true)
+  def size: Long
 
-  /**
-   * Returns a new bit vector with the `n`th bit low (and all other bits unmodified).
-   *
-   * @group individual
-   */
-  final def clear(n: Int): BitVector = updated(n, false)
+  // derived functions
 
   /**
    * Returns a new bit vector representing this vector's contents followed by the specified vector's contents.
    *
    * @group collection
    */
-  def ++(other: BitVector): BitVector
+  def ++(b2: BitVector): BitVector = {
+    def go(x: BitVector, y: BitVector, force: Boolean = false): BitVector =
+      if ((((x.size+y.size) % 8 == 0) && x.size <= 256 && y.size <= 256) ||
+          ((x.size >= 256 && x.size <= 512 && y.size >= 256 && y.size <= 512)))
+        // coalesce small bit vectors, preferring to obtain a byte-aligned result
+        x.compact.combine(y.compact)
+      else if (x.size >= y.size) x match {
+        case Append(l,r) if (x.size - y.size) >
+                            (r.size - y.size).abs =>
+          val r2 = r ++ y
+          // if the branches are not of roughly equal size,
+          // reinsert the left branch from the top
+          if (force || l.size*2 > r2.size) Append(l, r2)
+          else go(l, r2, force = true)
+        case _ => Append(x, y)
+      }
+      else y match {
+        case Append(l,r) if (y.size - x.size) >
+                            (r.size - x.size).abs =>
+          val l2 = x ++ l
+          if (force || r.size*2 > l2.size) Append(l2, r)
+          else go(l2, r, force = true)
+        case _ => Append(x, y)
+      }
+    if (b2.isEmpty) this
+    else if (this.isEmpty) b2
+    else go(this, b2)
+  }
+
+  /**
+   * Returns a bit vector of the same size with each bit shifted to the left `n` bits.
+   *
+   * @group bitwise
+   */
+  final def <<(n: Long): BitVector = leftShift(n)
+
+  /**
+   * Returns a bit vector of the same size with each bit shifted to the right `n` bits where the `n` left-most bits are sign extended.
+   *
+   * @group bitwise
+   */
+  final def >>(n: Long): BitVector = rightShift(n, true)
+
+  /**
+   * Returns a bit vector of the same size with each bit shifted to the right `n` bits where the `n` left-most bits are low.
+   *
+   * @group bitwise
+   */
+  final def >>>(n: Long): BitVector = rightShift(n, false)
+
+  /**
+   * Returns a bitwise AND of this vector with the specified vector.
+   *
+   * The resulting vector's size is the minimum of this vector's size and the specified vector's size.
+   *
+   * @group bitwise
+   */
+  final def &(other: BitVector): BitVector = and(other)
+
+  /**
+   * Returns a bitwise OR of this vector with the specified vector.
+   *
+   * The resulting vector's size is the minimum of this vector's size and the specified vector's size.
+   *
+   * @group bitwise
+   */
+  final def |(other: BitVector): BitVector = or(other)
+
+  /**
+   * Returns a bitwise XOR of this vector with the specified vector.
+   *
+   * The resulting vector's size is the minimum of this vector's size and the specified vector's size.
+   *
+   * @group bitwise
+   */
+  final def ^(other: BitVector): BitVector = xor(other)
+
+  /**
+   * Returns a bitwise AND of this vector with the specified vector.
+   *
+   * The resulting vector's size is the minimum of this vector's size and the specified vector's size.
+   *
+   * @group bitwise
+   */
+  def and(other: BitVector): BitVector = zipBytesWith(other)(_ & _)
+
+  /**
+   * Alias for `get`.
+   *
+   * @group individual
+   * @see get(Long)
+   */
+  final def apply(n: Long): Boolean = get(n)
+
+  /**
+   * Returns a vector whose contents are the results of taking the first `n` bits of this vector.
+   *
+   * If this vector does not contain at least `n` bits, an error message is returned.
+   *
+   * @see take
+   * @group collection
+   */
+  def acquire(n: Long): String \/ BitVector =
+    if (n <= size) right(take(n))
+    else left(s"cannot acquire $n bits from a vector that contains $size bits")
+
+  /**
+   * Returns a new bit vector with the `n`th bit low (and all other bits unmodified).
+   *
+   * @group individual
+   */
+  final def clear(n: Long): BitVector = updated(n, false)
+
+  /**
+   * Consumes the first `n` bits of this vector and decodes them with the specified function,
+   * resulting in a vector of the remaining bits and the decoded value. If this vector
+   * does not have `n` bits or an error occurs while decoding, an error is returned instead.
+   *
+   * @group collection
+   */
+   def consume[A](n: Long)(decode: BitVector => String \/ A): String \/ (BitVector, A) =
+     for {
+       toDecode <- acquire(n)
+       decoded <- decode(toDecode)
+     } yield (drop(n), decoded)
+
+  /**
+   * Returns `true` if the depth of this tree is `> d`. The result
+   * of `compact` has depth 0.
+   */
+  private[scodec] def depthExceeds(d: Int): Boolean = {
+    def go(node: BitVector, cur: Int): Boolean =
+      (cur > d) ||
+      (node match {
+        case Append(l,r) => go(l, cur+1) || go(r, cur+1)
+        case Drop(u,n) => go(u, cur+1)
+        case Bytes(b,n) => false
+      })
+    go(this, 0)
+  }
 
   /**
    * Returns a vector whose contents are the results of skipping the first `n` bits of this vector and taking the rest.
@@ -106,7 +203,200 @@ trait BitVector extends IndexedSeqOptimized[Boolean, BitVector] with BitwiseOper
    *
    * @group collection
    */
-  def drop(n: Int): BitVector
+  def drop(n: Long): BitVector =
+    if (n >= size) BitVector.empty
+    else if (n <= 0) this
+    else this match {
+      case Bytes(bytes, m) =>
+        if (n % 8 == 0) Bytes(bytes.drop((n/8).toInt), m-n)
+        else Drop(this.asInstanceOf[Bytes], n)
+      case Append(l,r) =>
+        if (l.size <= n) r.drop(n - l.size)
+        else l.drop(n) ++ r
+      case Drop(bytes, m) =>
+        bytes.drop(m + n)
+    }
+
+  /**
+   * Returns a vector whose contents are the results of skipping the last `n` bits of this vector.
+   *
+   * The resulting vector's size is `0 max (size - n)`
+   *
+   * @group collection
+   */
+  def dropRight(n: Long): BitVector =
+    if (n <= 0) this
+    else if (n >= size) BitVector.empty
+    else take(size - n)
+
+  /**
+   * Return a `BitVector` with the same contents as `this`, but
+   * based off a single `ByteVector`.
+   *
+   * This may involve copying data to a fresh `ByteVector`, but
+   * has the advantage that lookups index directly into a single
+   * `ByteVector` rather than traversing a logarithmic number of nodes
+   * in this tree.
+   *
+   * @group collection
+   */
+  def compact: Bytes = {
+    if (bytesNeededForBits(size) > Int.MaxValue)
+      throw new IllegalArgumentException(s"cannot compact bit vector of size ${size.toDouble / 8 / 1e9} GB")
+    def go(b: BitVector): Bytes = b match {
+      case Bytes(x,n) => Bytes(x,n)
+      case Append(l,r) => l.compact.combine(r.compact)
+      case Drop(b, from) =>
+        val low = from max 0
+        val newSize = b.size - low
+        if (newSize == 0) BitVector.empty.compact
+        else {
+          val lowByte = (low / 8).toInt
+          val shiftedByWholeBytes = b.compact.bytes.slice(lowByte, lowByte + bytesNeededForBits(newSize).toInt + 1)
+          val bitsToShiftEachByte = (low % 8).toInt
+          val newBytes = {
+            if (bitsToShiftEachByte == 0) shiftedByWholeBytes
+            else {
+              (shiftedByWholeBytes zipWithI (shiftedByWholeBytes.drop(1) :+ (0: Byte))) { case (a, b) =>
+                val hi = (a << bitsToShiftEachByte)
+                val low = (((b & topNBits(bitsToShiftEachByte)) & 0x000000ff) >>> (8 - bitsToShiftEachByte))
+                hi | low
+              }
+            }
+          }
+          Bytes(if (newSize <= (newBytes.size - 1) * 8) newBytes.dropRight(1) else newBytes, newSize)
+        }
+    }
+    go(this)
+  }
+
+  /**
+   * Returns the first bit in this vector.
+   *
+   * @throws IllegalArgumentException if this vector is empty
+   * @group individual
+   */
+  def head: Boolean = get(0)
+
+  /**
+   * Returns true if this bit vector has no bits.
+   *
+   * @group collection
+   */
+  final def isEmpty = size == 0L
+
+  /**
+   * Returns the number of bits in this vector, or `None` if the size does not
+   * fit into an `Int`.
+   *
+   * @group collection
+   */
+  def intSize: Option[Int] = if (size <= Int.MaxValue) Some(size.toInt) else None
+
+  /**
+   * Returns a bit vector of the same size with each bit shifted to the left `n` bits.
+   *
+   * @group bitwise
+   */
+  def leftShift(n: Long): BitVector =
+    if (n <= 0) this
+    else if (n >= size) BitVector.low(size)
+    else drop(n) ++ BitVector.low(n)
+
+  /**
+   * Returns `Some(true)` if the `n`th bit is high, `Some(false)` if low, and `None` if `n >= size`.
+   *
+   * @group individual
+   */
+  final def lift(n: Long): Option[Boolean] =
+    if (n < size) Some(get(n))
+    else None
+
+  /**
+   * Returns true if this bit vector has a non-zero number of bits.
+   *
+   * @group collection
+   */
+  final def nonEmpty = size > 0L
+
+  /**
+   * Returns a bitwise complement of this vector.
+   *
+   * @group bitwise
+   */
+  def not: BitVector = mapBytes(_.not)
+
+  /**
+   * Returns a bitwise OR of this vector with the specified vector.
+   *
+   * The resulting vector's size is the minimum of this vector's size and the specified vector's size.
+   *
+   * @group bitwise
+   */
+  def or(other: BitVector): BitVector = zipBytesWith(other)(_ | _)
+
+  /**
+   * Returns an `n`-bit vector whose contents are this vector's contents followed by 0 or more low bits.
+   *
+   * @throws IllegalArgumentException if `n < size`
+   * @group collection
+   */
+  def padTo(n: Long): BitVector =
+    if (n < size) throw new IllegalArgumentException(s"BitVector.padTo($n)")
+    else this ++ BitVector.fill(n - size)(false)
+
+  /**
+   * Reverse the bits of this vector.
+   */
+  def reverse: BitVector =
+    // todo: this has a log time implementation, assuming a balanced tree
+    BitVector(compact.bytes.reverse.map(reverseBitsInBytes _)).drop(8 - validBitsInLastByte(size))
+
+  /**
+   * Returns a new vector of the same size with the byte order reversed.
+   *
+   * @group collection
+   */
+  def reverseByteOrder: BitVector = {
+    if (size % 8 == 0) Bytes(compact.bytes.reverse, size)
+    else {
+      val validFinalBits = validBitsInLastByte(size)
+      val last = take(validFinalBits).compact
+      val b = drop(validFinalBits).toByteVector.reverse
+      val init = Bytes(b, size-last.size)
+      val res = (init ++ last)
+      require(res.size == size)
+      res
+    }
+  }
+
+  /**
+   * Returns a bit vector of the same size with each bit shifted to the right `n` bits.
+   *
+   * @param signExtension whether the `n` left-most bits should take on the value of bit 0
+   *
+   * @group bitwise
+   */
+  def rightShift(n: Long, signExtension: Boolean): BitVector = {
+    if (isEmpty || n <= 0) this
+    else {
+      val extensionHigh = signExtension && head
+      if (n >= size) {
+        if (extensionHigh) BitVector.high(size) else BitVector.low(size)
+      }
+      else {
+        (if (extensionHigh) BitVector.high(n) else BitVector.low(n)) ++
+        take(size - n)
+      }
+    }
+  }
+
+  /**
+   * Returns a new bit vector with the `n`th bit high (and all other bits unmodified).
+   *
+   * @group individual
+   */
+  final def set(n: Long): BitVector = updated(n, true)
 
   /**
    * Returns a vector whose contents are the results of taking the first `n` bits of this vector.
@@ -118,41 +408,57 @@ trait BitVector extends IndexedSeqOptimized[Boolean, BitVector] with BitwiseOper
    * @see acquire
    * @group collection
    */
-  def take(n: Int): BitVector
+  def take(n0: Long): BitVector = {
+    val n = n0 max 0
+    if (n >= size) this
+    else if (n == 0) BitVector.empty
+    else this match {
+      case Bytes(underlying, m) =>
+        // eagerly trim from underlying here
+        val m2 = n min m
+        val underlyingN = bytesNeededForBits(m2).toInt
+        Bytes(underlying.take(underlyingN), m2)
+      case Drop(underlying, m) => underlying.take(m + n).drop(m)
+      case Append(l, r) =>
+        if (n <= l.size) l.take(n)
+        else l ++ r.take(n-l.size)
+    }
+  }
 
   /**
-   * Returns a vector whose contents are the results of taking the first `n` bits of this vector.
+   * Returns a vector whose contents are the results of taking the last `n` bits of this vector.
    *
-   * If this vector does not contain at least `n` bits, an error message is returned.
+   * The resulting vector's size is `n min size`.
    *
-   * @see take
+   * Note: if an `n`-bit vector is required, use the `acquire` method instead.
+   *
+   * @see acquire
    * @group collection
    */
-  def acquire(n: Int): String \/ BitVector
+  def takeRight(n: Long): BitVector =
+    if (n < 0) throw new IllegalArgumentException(s"takeRight($n)")
+    else if (n >= size) this
+    else this.drop(size-n)
 
   /**
-   * Consumes the first `n` bits of this vector and decodes them with the specified function,
-   * resulting in a vector of the remaining bits and the decoded value. If this vector
-   * does not have `n` bits or an error occurs while decoding, an error is returned instead.
+   * Return the sequence of bits in this vector. The returned
+   * `IndexedSeq` is just a view; nothing is actually copied.
    *
+   * @throws IllegalArgumentException if this vector's size exceeds Int.MaxValue
+   * @see acquire
+   * @see toIndexedSeq
    * @group collection
    */
-  def consume[A](n: Int)(decode: BitVector => String \/ A): String \/ (BitVector, A)
-
-  /**
-   * Returns an `n`-bit vector whose contents are this vector's contents followed by 0 or more low bits.
-   *
-   * @throws IllegalArgumentException if `n` < `size`
-   * @group collection
-   */
-  def padTo(n: Int): BitVector
-
-  /**
-   * Returns a new vector of the same size with the byte order reversed.
-   *
-   * @group collection
-   */
-  def reverseByteOrder: BitVector
+  def toIndexedSeq: IndexedSeq[Boolean] = {
+    intSize.map { n =>
+      new IndexedSeq[Boolean] {
+        def length = BitVector.this.size.toInt
+        def apply(idx: Int): Boolean = BitVector.this.get(idx.toLong)
+      }
+    }.getOrElse {
+      throw new IllegalArgumentException(s"BitVector too big for Seq: $size")
+    }
+  }
 
   /**
    * Converts the contents of this vector to a byte vector.
@@ -162,7 +468,8 @@ trait BitVector extends IndexedSeqOptimized[Boolean, BitVector] with BitwiseOper
    *
    * @group conversions
    */
-  def toByteVector: ByteVector
+  def toByteVector: ByteVector =
+    clearUnneededBits(size, compact.bytes)
 
   /**
    * Converts the contents of this vector to a byte array.
@@ -172,7 +479,7 @@ trait BitVector extends IndexedSeqOptimized[Boolean, BitVector] with BitwiseOper
    *
    * @group conversions
    */
-  def toByteArray: Array[Byte]
+  def toByteArray: Array[Byte] = toByteVector.toArray
 
   /**
    * Converts the contents of this vector to a `java.nio.ByteBuffer`.
@@ -183,23 +490,206 @@ trait BitVector extends IndexedSeqOptimized[Boolean, BitVector] with BitwiseOper
    * @see toByteVector
    * @group conversions
    */
-  def toByteBuffer: ByteBuffer
+  def toByteBuffer: java.nio.ByteBuffer = toByteVector.toByteBuffer
+
+  /**
+   * Returns a bitwise complement of this vector.
+   *
+   * @group bitwise
+   */
+  final def unary_~(): BitVector = not
+
+  /**
+   * Returns a bitwise XOR of this vector with the specified vector.
+   *
+   * The resulting vector's size is the minimum of this vector's size and the specified vector's size.
+   *
+   * @group bitwise
+   */
+  def xor(other: BitVector): BitVector = zipBytesWith(other)(_ ^ _)
+
+  override def equals(other: Any): Boolean = other match {
+    case o: BitVector if size == o.size => {
+      var i = 0L
+      while (i < size) {
+        if (get(i) != o.get(i)) return false
+        i += 1
+      }
+      return true
+    }
+    case _ => false
+  }
+
+  /**
+   * Computed by sampling bits `Stream.iterate(0L)(n => (n*1.7).toLong + 1)`,
+   * up until the maximum index. The result is cached.
+   */
+  override lazy val hashCode = {
+    // todo: this could be recomputed more efficiently using the tree structure
+    // given an associative hash function
+    import util.hashing.MurmurHash3._
+    var h = stringHash("BitVector")
+    var i = 0L
+    while (i < size) {
+      h = mix(h, get(i).hashCode)
+      i = (i * 1.7).toLong + 1 // 0, 1, 2, 4, 7, 12, 21, ...
+    }
+    finalizeHash(h, size.toInt)
+  }
+
+  /**
+   * Display the size and bytes of this `BitVector`.
+   * For bit vectors beyond a certain size, only a hash of the
+   * contents are shown.
+   */
+  override def toString =
+    if (size < 512) s"BitVector($size bits, 0x${toByteVector.toHex})"
+    else s"BitVector($size bits, #${hashCode})"
+
+  // impl details
+
+  protected def checkBounds(n: Long): Unit =
+    if (n >= size) outOfBounds(n)
+
+  protected def outOfBounds(n: Long): Nothing =
+    throw new NoSuchElementException(s"invalid index: $n of $size")
+
+  private def mapBytes(f: ByteVector => ByteVector): BitVector = this match {
+    case Bytes(bytes, n) => Bytes(f(bytes), n)
+    case Append(l,r) => Append(l.mapBytes(f), r.mapBytes(f))
+    case Drop(b,n) => Drop(b.mapBytes(f).compact, n)
+  }
+
+  /**
+   * Pretty print this `BitVector`.
+   */
+  private[scodec] def internalPretty(prefix: String): String = this match {
+    case Append(l,r) => prefix + "append\n" +
+                        l.internalPretty(prefix + "  ") + "\n" +
+                        r.internalPretty(prefix + "  ")
+    case Bytes(b, n) =>
+      if (n > 16) prefix + s"bits $n #:${b.hashCode}"
+      else        prefix + s"bits $n 0x${b.toHex}"
+    case Drop(u, n) => prefix + s"drop ${n}\n" +
+                       u.internalPretty(prefix + "  ")
+  }
+
+  private def zipBytesWith(other: BitVector)(op: (Byte, Byte) => Int): BitVector = {
+    // todo: this has a much more efficient recursive algorithm -
+    // only need to compact close to leaves of the tree
+    Bytes(this.compact.bytes.zipWithI(other.compact.bytes)(op), this.size min other.size)
+  }
+
 }
 
 object BitVector {
 
-  val empty: BitVector = BitVector(ByteVector.empty)
+  val empty: BitVector = Bytes(ByteVector.empty, 0)
+  val zero: BitVector = Bytes(ByteVector(0), 1)
+  val one: BitVector = Bytes(ByteVector(1), 1)
+  val highByte: BitVector = Bytes(ByteVector.fill(8)(1), 8)
+  val lowByte: BitVector = Bytes(ByteVector.fill(8)(0), 8)
 
-  def high(n: Int): BitVector = apply(n, ByteVector.fill((n + 7) / 8)(-1))
-  def low(n: Int): BitVector = apply(n, ByteVector.fill((n + 7) / 8)(0))
+  def bit(high: Boolean): BitVector = fill(1)(high)
 
-  private def apply(n: Int, bytes: ByteVector): BitVector =
-    new SimpleBitVector(n, clearUnneededBits(n, bytes))
+  def bits(b: Iterable[Boolean]): BitVector =
+    b.zipWithIndex.foldLeft(low(b.size))((acc,b) =>
+      acc.updated(b._2, b._1)
+    )
 
-  def apply(bytes: ByteVector): BitVector = new SimpleBitVector(bytes.size * 8, bytes)
-  def apply(bytes: Array[Byte]): BitVector = apply(ByteVector(bytes))
+  def high(n: Long): BitVector = fill(n)(true)
+  def low(n: Long): BitVector = fill(n)(false)
+
+  def apply(bytes: ByteVector): BitVector = Bytes(bytes, bytes.size.toLong * 8)
   def apply(buffer: ByteBuffer): BitVector = apply(ByteVector(buffer))
+  def apply(bytes: Array[Byte]): BitVector = Bytes(ByteVector(bytes), bytes.size.toLong * 8)
   def apply[A: Integral](bytes: A*): BitVector = apply(ByteVector(bytes: _*))
+
+  def fill(n: Long)(high: Boolean): BitVector = {
+    val needed = bytesNeededForBits(n)
+    if (needed < Int.MaxValue) {
+      val bytes = ByteVector.fill(needed.toInt)(if (high) -1 else 0)
+      Bytes(bytes, n)
+    }
+    else {
+      fill(n / 2)(high) ++ fill(n - (n/2))(high)
+    }
+  }
+
+  object Bytes {
+    def apply(bytes: ByteVector, size: Long): Bytes = {
+      val needed = bytesNeededForBits(size)
+      require(needed <= bytes.size)
+      val b = if (bytes.size > needed) bytes.take(needed.toInt) else bytes
+      // new Bytes(clearUnneededBits(size, b), size)
+      new Bytes(b, size)
+    }
+
+    def unapply(b: BitVector): Option[(ByteVector, Long)] = b match {
+      case bs: Bytes => Some((bs.bytes, bs.size))
+      case _ => None
+    }
+  }
+  private[scodec] class Bytes(val bytes: ByteVector, val size: Long) extends BitVector {
+    private val invalidBits = 8 - validBitsInLastByte(size)
+    def get(n: Long): Boolean = {
+      checkBounds(n)
+      getBit(bytes((n / 8).toInt), (n % 8).toInt)
+    }
+    def updated(n: Long, high: Boolean): BitVector = {
+      checkBounds(n)
+      val b2 = bytes.updated(
+        (n / 8).toInt,
+        bytes.lift((n / 8).toInt).map(setBit(_, (n % 8).toInt, high)).getOrElse {
+          outOfBounds(n)
+        }
+      )
+      Bytes(b2, size)
+    }
+    def combine(other: Bytes): Bytes = {
+      val otherBytes = other.bytes
+      if (isEmpty) {
+        other
+      } else if (otherBytes.isEmpty) {
+        this
+      } else if (invalidBits == 0) {
+        Bytes(bytes ++ otherBytes, size + other.size)
+      } else {
+        val bytesCleared = clearUnneededBits(size, bytes) // this is key
+        val hi = bytesCleared(bytesCleared.size - 1)
+        val otherInvalidBits = (if (other.size % 8 == 0) 0 else (8 - (other.size % 8))).toInt
+        val lo = (((otherBytes.head & topNBits(invalidBits.toInt)) & 0x000000ff) >>> validBitsInLastByte(size)).toByte
+        //val lo = (((otherBytes.head & topNBits(8 - otherInvalidBits)) & 0x000000ff) >>> validBitsInLastByte(size)).toByte
+        val updatedOurBytes = bytesCleared.updated(bytesCleared.size - 1, (hi | lo).toByte)
+        val updatedOtherBytes = other.drop(invalidBits).toByteVector
+        Bytes(updatedOurBytes ++ updatedOtherBytes, size + other.size)
+      }
+    }
+  }
+
+  private[scodec] case class Drop(underlying: Bytes, m: Long) extends BitVector {
+    val size = underlying.size - m
+    def get(n: Long): Boolean =
+      underlying.get(m + n)
+    def updated(n: Long, high: Boolean): BitVector =
+      Drop(underlying.updated(m + n, high).compact, m)
+  }
+  private[scodec] case class Append(left: BitVector, right: BitVector) extends BitVector {
+    val size = left.size + right.size
+    def get(n: Long): Boolean =
+      if (n < left.size) left.get(n)
+      else right.get(n - left.size)
+    def updated(n: Long, high: Boolean): BitVector =
+      if (n < left.size) Append(left.updated(n, high), right)
+      else Append(left, right.updated(n - left.size, high))
+  }
+
+  implicit val monoidInstance: scalaz.Monoid[BitVector] = new scalaz.Monoid[BitVector] {
+    override def zero: BitVector = BitVector.empty
+    override def append(x: BitVector, y: => BitVector) = x ++ y
+  }
+
+  // bit twiddling operations
 
   private def getBit(byte: Byte, n: Int): Boolean =
     ((0x00000080 >> n) & byte) != 0
@@ -209,30 +699,17 @@ object BitVector {
     else (~(0x00000080 >> n)) & byte
   }.toByte
 
+  private def validBitsInLastByte(size: Long): Long = {
+    val mod = size % 8
+    (if (mod == 0) 8 else mod)
+  }
+
   /** Gets a byte mask with the top `n` bits enabled. */
   private def topNBits(n: Int): Byte =
     (-1 << (8 - n)).toByte
 
-  private def bytesNeededForBits(size: Int): Int =
+  private def bytesNeededForBits(size: Long): Long =
     (size + 7) / 8
-
-  /** Number of bits (1 - 8) in the last byte of a vector of the specified size. */
-  private def validBitsInLastByte(size: Int): Int = {
-    val mod = size % 8
-    if (mod == 0) 8 else mod
-  }
-
-  /** Clears (sets to 0) any bits in the last byte that are not used for storing `size` bits. */
-  private def clearUnneededBits(size: Int, bytes: ByteVector): ByteVector = {
-    val valid = validBitsInLastByte(size)
-    if (valid < 8) {
-      val idx = bytes.size - 1
-      val last = bytes(idx)
-      bytes.updated(idx, (last & topNBits(valid)).toByte)
-    } else {
-      bytes
-    }
-  }
 
   private def reverseBitsInBytes(b: Byte): Byte = {
     // See Hacker's Delight Chapter 7 page 101
@@ -242,189 +719,16 @@ object BitVector {
     x.toByte
   }
 
-  implicit val monoidInstance: Monoid[BitVector] = new Monoid[BitVector] {
-    override def zero: BitVector = BitVector.empty
-    override def append(x: BitVector, y: => BitVector) = x ++ y
-  }
-
-
-  private class SimpleBitVector(val length: Int, bytes: ByteVector) extends BitVector with Serializable {
-
-    require(size >= 0, "size must be non-negative")
-    require(bytes.size == bytesNeededForBits(size), s"size ($size) and bytes.size (${bytes.size}) are not compatible")
-
-    /** Number of bits (0 - 7) in the last bye of bytes that are not part of vector. */
-    private val invalidBits = 8 - validBitsInLastByte(size)
-
-    def get(n: Int) = lift(n) getOrElse { throw new NoSuchElementException(s"Cannot get bit $n from vector of $size bits") }
-
-    def lift(n: Int) = for {
-      byte <- bytes.lift(n / 8)
-    } yield getBit(byte, n % 8)
-
-    def updated(n: Int, high: Boolean): BitVector =
-      new SimpleBitVector(size, bytes.updated(n / 8, setBit(bytes(n / 8), n % 8, high)))
-
-    override def slice(from: Int, until: Int): BitVector = {
-      val low = from max 0
-      val high = until max 0 min size
-      val newSize = (high - low) max 0
-
-      if (newSize == 0) {
-        BitVector.empty
-      } else {
-        val lowByte = low / 8
-        val shiftedByWholeBytes = bytes.slice(lowByte, lowByte + bytesNeededForBits(newSize) + 1)
-        val bitsToShiftEachByte = low % 8
-        val newBytes = {
-          if (bitsToShiftEachByte == 0) shiftedByWholeBytes
-          else {
-            (shiftedByWholeBytes zipWithI (shiftedByWholeBytes.drop(1) :+ (0: Byte))) { case (a, b) =>
-              val hi = (a << bitsToShiftEachByte)
-              val low = (((b & topNBits(bitsToShiftEachByte)) & 0x000000ff) >>> (8 - bitsToShiftEachByte))
-              hi | low
-            }
-          }
-        }
-        BitVector(newSize, if (newSize <= (newBytes.size - 1) * 8) newBytes.dropRight(1) else newBytes)
-      }
-    }
-
-    def acquire(n: Int): String \/ BitVector = {
-      if (size < n) \/ left s"cannot acquire $n bits from a vector that contains $size bits"
-      else \/ right take(n)
-    }
-
-    def consume[A](n: Int)(decode: BitVector => String \/ A): String \/ (BitVector, A) = for {
-      toDecode <- acquire(n)
-      decoded <- decode(toDecode)
-    } yield (drop(n), decoded)
-
-    def padTo(n: Int) = {
-      if (n <= size) this
-      else this ++ BitVector.low(n - size)
-    }
-
-    def reverseByteOrder = {
-      val validBitsInLastByte = 8 - invalidBits
-      val last = take(validBitsInLastByte)
-      val init = drop(validBitsInLastByte).toByteVector.reverse.toBitVector.take(size - last.size)
-      (init ++ last)
-    }
-
-    def ++(other: BitVector): BitVector = {
-      val otherBytes = other.toByteVector
-      if (isEmpty) {
-        other
-      } else if (otherBytes.isEmpty) {
-        this
-      } else if (invalidBits == 0) {
-        new SimpleBitVector(size + other.size, bytes ++ otherBytes)
-      } else {
-        val hi = bytes(bytes.size - 1)
-        val lo = (((otherBytes.head & topNBits(invalidBits)) & 0x000000ff) >>> validBitsInLastByte(size)).toByte
-        val updatedOurBytes = bytes.updated(bytes.size - 1, (hi | lo).toByte)
-        val updatedOtherBytes = other.drop(invalidBits).toByteVector
-        new SimpleBitVector(size + other.size, updatedOurBytes ++ updatedOtherBytes)
-      }
-    }
-
-    def leftShift(n: Int): BitVector = {
-      if (n <= 0) this
-      else if (n >= size) BitVector.low(size)
-      else drop(n) ++ BitVector.low(n)
-    }
-
-    def rightShift(n: Int, signExtension: Boolean): BitVector = {
-      if (isEmpty || n <= 0) this
-      else {
-        val extensionHigh = signExtension && (bytes.head & 0x00000080) != 0
-        if (n >= size) {
-          if (extensionHigh) BitVector.high(size) else BitVector.low(size)
-        } else {
-          (if (extensionHigh) BitVector.high(n) else BitVector.low(n)) ++ take(size - n)
-        }
-      }
-    }
-
-    def not: BitVector =
-      BitVector(size, bytes mapI { ~_ })
-
-    def and(other: BitVector): BitVector =
-      zipBytesWith(other)(_ & _)
-
-    def or(other: BitVector): BitVector =
-      zipBytesWith(other)(_ | _)
-
-    def xor(other: BitVector): BitVector =
-      zipBytesWith(other)(_ ^ _)
-
-    private def zipBytesWith(other: BitVector)(op: (Byte, Byte) => Int): BitVector =
-      BitVector(size min other.size, (bytes zipWithI other.toByteVector)(op))
-
-    override def reverse: BitVector =
-      BitVector(bytes.reverse.map(BitVector.reverseBitsInBytes _)).drop(invalidBits)
-
-    def toByteVector = bytes
-
-    def toByteArray = bytes.toArray
-
-    def toByteBuffer = ByteBuffer.wrap(bytes.toArray)
-
-    def seq: IndexedSeq[Boolean] = {
-      val bldr = Vector.newBuilder[Boolean]
-      for (i <- 0 until length)
-        bldr += get(i)
-      bldr.result
-    }
-
-    override protected[this] def thisCollection = seq
-
-    override def hashCode: Int =
-      bytes.hashCode
-
-    override def equals(other: Any): Boolean = other match {
-      case o: BitVector => bytes == o.toByteVector
-      case _ => false
-    }
-
-    override def toString = {
-      if (isEmpty) {
-        "BitVector(0 bits)"
-      } else {
-        val hex = bytes.toHex
-        val truncatedHex = if (invalidBits >= 4) {
-          hex.substring(0, hex.size - 1)
-        } else hex
-        s"BitVector($size bits, $truncatedHex)"
-      }
-    }
-
-    override protected[this] def newBuilder: Builder[Boolean, BitVector] = new Builder[Boolean, BitVector] {
-      private var length = 0
-      private var currentByte: Byte = 0
-      private var doneBytes = Vector.newBuilder[Byte]
-
-      def +=(bit: Boolean) = {
-        currentByte = setBit(currentByte, length, bit)
-        length += 1
-        this
-      }
-
-      def clear() {
-        length = 0
-        currentByte = 0
-        doneBytes.clear()
-      }
-
-      def result(): BitVector = {
-        if (length == 0) {
-          BitVector.empty
-        } else {
-          val bytes = (doneBytes += currentByte).result()
-          new SimpleBitVector(length, ByteVector(bytes))
-        }
-      }
+  /** Clears (sets to 0) any bits in the last byte that are not used for storing `size` bits. */
+  private def clearUnneededBits(size: Long, bytes: ByteVector): ByteVector = {
+    val valid = validBitsInLastByte(size).toInt
+    if (bytes.nonEmpty && valid < 8) {
+      val idx = bytes.size - 1
+      val last = bytes(idx)
+      bytes.updated(idx, (last & topNBits(valid)).toByte)
+    } else {
+      bytes
     }
   }
 }
+

--- a/src/test/scala/scodec/BitVectorTest.scala
+++ b/src/test/scala/scodec/BitVectorTest.scala
@@ -1,13 +1,26 @@
 package scodec
 
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{Arbitrary, Gen, Shrink}
 import org.scalatest._
 import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 
 class BitVectorTest extends FunSuite with Matchers with GeneratorDrivenPropertyChecks {
 
-  implicit val arbitraryBitVector: Arbitrary[BitVector] = Arbitrary(genBitVector(500, 7))
+  implicit val arbitraryBitVector: Arbitrary[BitVector] =
+    Arbitrary(Gen.oneOf(
+      genBitVector(500, 7),             // regular flat bit vectors
+      genConcat(genBitVector(2000, 7)), // balanced trees of concatenations
+      genSplit(5000),                   // split bit vectors: b.take(m) ++ b.drop(m)
+      genConcat(genSplit(5000))))       // concatenated split bit vectors
+
+  implicit val shrinkBitVector: Shrink[BitVector] =
+    Shrink[BitVector] { b =>
+      if (b.nonEmpty)
+        Stream.iterate(b.take(b.size / 2))(b2 => b2.take(b2.size / 2)).takeWhile(_.nonEmpty) ++
+        Stream(BitVector.empty)
+      else Stream.empty
+    }
 
   def genBitVector(maxBytes: Int, maxAdditionalBits: Int): Gen[BitVector] = for {
     byteSize <- Gen.choose(0, maxBytes)
@@ -15,6 +28,32 @@ class BitVectorTest extends FunSuite with Matchers with GeneratorDrivenPropertyC
     size = byteSize * 8 + additionalBits
     bytes <- Gen.listOfN((size + 7) / 8, Gen.choose(0, 255))
   } yield BitVector(ByteVector(bytes: _*)).take(size)
+
+  def genSplit(maxSize: Long) = for {
+    n <- Gen.choose(0L, maxSize)
+    b <- genBitVector(15, 7)
+  } yield {
+    val m = if (b.nonEmpty) (n % b.size).abs else 0
+    b.take(m) ++ b.drop(m)
+  }
+
+  def genConcat(g: Gen[BitVector]) =
+    genBitVector(2000, 7).map { b =>
+      b.toIndexedSeq.foldLeft(BitVector.empty)(
+        (acc,high) => acc ++ BitVector.bit(high)
+      )
+    }
+
+  test("hashCode/equals") {
+    forAll { (b: BitVector, b2: BitVector, m: Long) =>
+      val n = if (b.nonEmpty) (m % b.size).abs else 0
+      (b.take(m) ++ b.drop(m)).hashCode shouldBe b.hashCode
+      if (b.take(3) == b2.take(3)) {
+        // kind of weak, since this will only happen 1/8th of attempts on average
+        b.take(3).hashCode shouldBe b2.take(3).hashCode
+      }
+    }
+  }
 
   test("construction via high") {
     BitVector.high(1).toByteVector shouldBe ByteVector(0x80)
@@ -64,32 +103,62 @@ class BitVectorTest extends FunSuite with Matchers with GeneratorDrivenPropertyC
     BitVector.high(8).drop(4).toByteVector shouldBe ByteVector(0xf0)
     BitVector.high(8).drop(3).toByteVector shouldBe ByteVector(0xf8)
     BitVector.high(10).drop(3).toByteVector shouldBe ByteVector(0xfe)
+    BitVector.high(10).drop(3) shouldBe BitVector.high(7)
     BitVector.high(12).drop(3).toByteVector shouldBe ByteVector(0xff, 0x80)
     BitVector.empty.drop(4) shouldBe BitVector.empty
     BitVector.high(4).drop(8) shouldBe BitVector.empty
+    forAll { (x: BitVector, n: Long) =>
+      val m = if (x.nonEmpty) (n % x.size).abs else 0
+      x.compact.drop(m).toIndexedSeq.take(4) shouldBe x.toIndexedSeq.drop(m.toInt).take(4)
+      x.compact.drop(m).compact.toIndexedSeq.take(4) shouldBe x.toIndexedSeq.drop(m.toInt).take(4)
+    }
   }
 
-  test("take") {
+  test("take/drop") {
     BitVector.high(8).take(4).toByteVector shouldBe ByteVector(0xf0)
+    BitVector.high(8).take(4) shouldBe BitVector.high(4)
     BitVector.high(8).take(5).toByteVector shouldBe ByteVector(0xf8)
+    BitVector.high(8).take(5) shouldBe BitVector.high(5)
     BitVector.high(10).take(7).toByteVector shouldBe ByteVector(0xfe)
+    BitVector.high(10).take(7) shouldBe BitVector.high(7)
     BitVector.high(12).take(9).toByteVector shouldBe ByteVector(0xff, 0x80)
+    BitVector.high(12).take(9) shouldBe BitVector.high(9)
     BitVector.high(4).take(100).toByteVector shouldBe ByteVector(0xf0)
-  }
-
-  test("bv.take(n) ++ bv.drop(n) == bv") {
-    forAll { (bv: BitVector, n: Int) =>
-      val m = n % bv.size
-      bv.take(m) ++ bv.drop(m) shouldBe bv
+    forAll { (x: BitVector, n0: Long, m0: Long) =>
+      val m = if (x.nonEmpty) (m0 % x.size).abs else 0
+      val n = if (x.nonEmpty) (n0 % x.size).abs else 0
+      (x.take(m) ++ x.drop(m)).compact shouldBe x
+      x.take(m+n).compact.take(n) shouldBe x.take(n)
+      x.drop(m+n).compact shouldBe x.drop(m).compact.drop(n)
+      x.drop(n).take(m).toIndexedSeq shouldBe BitVector.bits(x.drop(n).toIndexedSeq).take(m).toIndexedSeq
     }
   }
 
   test("dropRight") {
     BitVector.high(12).clear(0).dropRight(4).toByteVector shouldBe ByteVector(0x7f)
+    forAll { (x: BitVector, n0: Long, m0: Long) =>
+      val m = if (x.nonEmpty) (m0 % x.size).abs else 0
+      val n =  if (x.nonEmpty) (n0 % x.size).abs else 0
+      x.dropRight(m).dropRight(n) shouldBe x.dropRight(m + n)
+      x.dropRight(m) shouldBe x.take(x.size - m)
+    }
   }
 
   test("takeRight") {
     BitVector.high(12).clear(0).takeRight(4).toByteVector shouldBe ByteVector(0xf0)
+    forAll { (x: BitVector, n0: Long, m0: Long) =>
+      val m = if (x.nonEmpty) (m0 % x.size).abs else 0
+      val n =  if (x.nonEmpty) (n0 % x.size).abs else 0
+      x.takeRight(m max n).takeRight(n).compact shouldBe x.takeRight(n)
+      x.takeRight(m) shouldBe x.drop(x.size - m)
+    }
+  }
+
+  test("compact") {
+    forAll { (x: BitVector) =>
+      x.compact shouldBe x
+      x.depthExceeds(16) shouldBe false
+    }
   }
 
   test("++") {
@@ -100,6 +169,24 @@ class BitVectorTest extends FunSuite with Matchers with GeneratorDrivenPropertyC
     (BitVector.high(4) ++ BitVector.high(5)).toByteVector shouldBe ByteVector(-1: Byte, 0x80)
     (BitVector.low(2) ++ BitVector.high(4)).toByteVector shouldBe ByteVector(0x3c)
     (BitVector.low(2) ++ BitVector.high(4) ++ BitVector.low(2)).toByteVector shouldBe ByteVector(0x3c)
+    forAll { (x: BitVector, y: BitVector) =>
+      (x ++ y).compact.toIndexedSeq shouldBe (x.toIndexedSeq ++ y.toIndexedSeq)
+    }
+  }
+
+  test("b.take(n).drop(n) == b") {
+    implicit val intGen = Arbitrary(Gen.choose(0,10000))
+    forAll { (xs: List[Boolean], n0: Int, m0: Int) =>
+      whenever(xs.nonEmpty) {
+        val n = n0.abs % xs.size
+        val m = m0.abs % xs.size
+        xs.drop(m).take(n) shouldBe xs.take(m+n).drop(m)
+      }
+    }
+    forAll { (xs: BitVector, n0: Long) =>
+      val m = if (xs.nonEmpty) n0 % xs.size else 0
+      (xs.take(m) ++ xs.drop(m)).compact shouldBe xs
+    }
   }
 
   test("<<") {
@@ -156,8 +243,8 @@ class BitVectorTest extends FunSuite with Matchers with GeneratorDrivenPropertyC
     BitVector(10, 245) ^ BitVector(245, 10) shouldBe BitVector.high(16)
   }
 
-  test("toIterable") {
-    BitVector.high(8).toIterable
+  test("toIndexedSeq") {
+    BitVector.high(8).toIndexedSeq shouldBe List.fill(8)(true)
   }
 
   test("reverse") {
@@ -165,7 +252,9 @@ class BitVectorTest extends FunSuite with Matchers with GeneratorDrivenPropertyC
     BitVector(0x03, 0x80).reverse shouldBe BitVector(0x01, 0xc0)
     BitVector(0x01, 0xc0).reverse shouldBe BitVector(0x03, 0x80)
     BitVector(0x30).take(4).reverse shouldBe BitVector(0xc0).take(4)
-    forAll { (bv: BitVector) => bv.reverse.reverse shouldBe bv }
+    forAll { (bv: BitVector) =>
+      bv.reverse.reverse shouldBe bv
+    }
   }
 
   test("reverseByteOrder") {
@@ -175,4 +264,5 @@ class BitVectorTest extends FunSuite with Matchers with GeneratorDrivenPropertyC
       bv.reverseByteOrder.reverseByteOrder shouldBe bv
     }
   }
+
 }


### PR DESCRIPTION
Squashed version of #2, which can be closed.

`BitVector` is now a balanced binary tree of byte vectors, with some extra logic to handle trailing bits. Indexing into a `BitVector` is done with `Long` (to allow vectors of sizes greater than 250MB or so), and `take`, `drop`, and `++` are all log time operations. The new `BitVector` no longer extends the Scala collections due to the move to `Long` based indexing, but all the operations that are used in `scodec` are implemented directly for `BitVector`, so all the existing code still compiles.

The new implementation relies on the efficiency of `ByteVector.take/drop/slice`, but does not rely on the efficiency of `ByteVector.updated` - trailing bits are always left alone and only when flattening a `BitVector` to a `ByteVector` are these bits cleared. Thus, `BitVector(hugeByteVector).take(13).toByteVector` will only be calling `updated` on a two byte slice of `hugeByteVector`, rather than clearing those bits on `hugeByteVector`. So this implementation should work fine for 'dumber' `ByteVector` implementations that just make a full copy of the underlying bytes.

I added lots of scalacheck properties, including merging the `x.take(m) ++ x.drop(m) == x` property from master. All tests are passing.

Other notes:
- The `++` operation merges small bit vectors (those below 512 bytes) into flat byte vectors, but if the vectors are very small (both below 256 bits), it prefers to wait until the combined size is divisible by 8. This is to avoid having weird bit lengths sprinkled throughout the tree that would result in needing to shift individual bytes when flattening. I haven't tried tuning these constants, but that would be something interesting to play with and profile.
- A few operations, like `reverse`, `reverseByteOrder`, and the pairwise binary operators like `and` and `or`, could be written more efficiently to take advantage of the tree structure. Currently, they do the dumbest possible thing of just flattening the overall vector (which makes them roughly equivalent to what was there before).
- I found it worked out a little nicer to have a `Drop` constructor separate from the flat `Bytes` constructor. This way each flat `Bytes` slice starts on a byte boundary, and there are fewer places in the code where you need to worry about byte-boundary issues. If you look at the implementation of `drop`, it actually only creates a `Drop` node if it needs to split a byte in two, otherwise it just takes a whole-byte slice of some underlying `ByteVector`.
