### PR TITLE
generalize SignatureCodec to support checksums and Digests

### DIFF
--- a/src/main/scala/scodec/codecs/ChecksumCodec.scala
+++ b/src/main/scala/scodec/codecs/ChecksumCodec.scala
@@ -1,0 +1,86 @@
+package scodec
+package codecs
+
+import java.security.MessageDigest
+import java.util.Arrays
+import java.util.zip.{ CRC32, Adler32, Checksum }
+import scodec.bits.ByteVector
+
+/**
+ * Create "checksum" implementations for [[SignerFactory]]
+ * @group checksum
+ */
+object ChecksumFactory {
+  /**
+   * Creates a `java.security.Digest` factory for the specified algorithm
+   * 
+   */
+  def digest(algorithm: String): SignerFactory =
+    new DigestFactory(algorithm)
+
+  /**
+   * Fletcher-16 checksum
+   */
+  val fletcher16: SignerFactory = new ChecksumFactory {
+    def newSigner = new Fletcher16Checksum
+  }
+
+  /**
+   * CRC-32 checksum
+   */
+  val crc32: SignerFactory = new ChecksumFactory {
+    def newSigner = new ZipChecksumSigner(new CRC32())
+  }
+
+  /**
+   * Adler-32 checksum
+   */
+  val adler32: SignerFactory = new ChecksumFactory {
+    def newSigner = new ZipChecksumSigner(new Adler32())
+  }
+
+  /**
+   * `java.security.Digest` implementation of Signer
+   */
+  private class DigestSigner(impl: MessageDigest) extends Signer {
+    def update(data: Array[Byte]): Unit = impl.update(data)
+    def sign: Array[Byte] = impl.digest
+    def verify(signature: Array[Byte]): Boolean = MessageDigest.isEqual(impl.digest(), signature)
+  }
+
+  /**
+   * A checksum does not have a distinct verify implementation
+   */
+  private trait ChecksumFactory extends SignerFactory {
+    def newVerifier: Signer = newSigner
+  }
+
+  private class DigestFactory(val algorithm: String) extends ChecksumFactory {
+    def newSigner: Signer = new DigestSigner(MessageDigest.getInstance(algorithm))
+  }
+
+  /**
+   * http://en.wikipedia.org/wiki/Fletcher's_checksum
+   */
+  private class Fletcher16Checksum extends Signer {
+    var checksum = (0, 0)
+    def update(data: Array[Byte]): Unit = {
+      checksum = data.foldLeft(checksum) { (p, b) =>
+        val lsb = (p._2 + (0xff & b)) % 255
+        ((p._1 + lsb) % 255, lsb)
+      }
+    }
+    def sign: Array[Byte] = Array(checksum._1.asInstanceOf[Byte], checksum._2.asInstanceOf[Byte])
+    def verify(signature: Array[Byte]): Boolean = Arrays.equals(sign, signature)
+  }
+
+  /**
+   * `java.util.zip.Checksum` implementation of Signer
+   */
+  private class ZipChecksumSigner(impl: Checksum) extends Signer {
+    def update(data: Array[Byte]): Unit = impl.update(data, 0, data.length)
+    def sign: Array[Byte] = ByteVector.fromLong(impl.getValue()).drop(4).toArray
+    def verify(signature: Array[Byte]): Boolean = MessageDigest.isEqual(sign, signature)
+  }
+
+} 

--- a/src/main/scala/scodec/codecs/package.scala
+++ b/src/main/scala/scodec/codecs/package.scala
@@ -86,11 +86,16 @@ import scodec.bits.{ BitVector, ByteOrdering, ByteVector }
  * Note: this design is heavily based on Scala's parser combinator library and the syntax it provides.
  *
  *
- * === Cryptograhpy Codecs ===
+ * === Cryptography Codecs ===
  *
  * There are codecs that support working with encrypted data ([[encrypted]]) and digital signatures
  * ([[fixedSizeSignature]] and [[variableSizeSignature]]). Additionally, support for `java.security.cert.Certificate`s
  * is provided by [[certificate]] and [[x509Certificate]].
+ * 
+ * === Checksum Codecs ===
+ *
+ * There are codecs that support working with checksums and digests, extending the 
+ * [[fixedSizeSignature]] and [[variableSizeSignature]] functionality.
  *
  *
  * @groupname bits Bits and Bytes Codecs
@@ -110,6 +115,9 @@ import scodec.bits.{ BitVector, ByteOrdering, ByteVector }
  *
  * @groupname crypto Cryptography
  * @groupprio crypto 4
+ * 
+ * @groupname checksum Checksums and Digests
+ * @groupprio checksum 5
  */
 package object codecs {
 
@@ -826,7 +834,7 @@ package object codecs {
    * @param signatureFactory factory to use for signing/verifying
    * @group crypto
    */
-  def fixedSizeSignature[A](size: Int)(codec: Codec[A])(implicit signatureFactory: SignatureFactory): Codec[A] =
+  def fixedSizeSignature[A](size: Int)(codec: Codec[A])(implicit signatureFactory: SignerFactory): Codec[A] =
     new SignatureCodec(codec, fixedSizeBytes(size, BitVectorCodec))(signatureFactory)
 
   /**
@@ -840,7 +848,7 @@ package object codecs {
    * @param signatureFactory factory to use for signing/verifying
    * @group crypto
    */
-  def variableSizeSignature[A](size: Codec[Int])(codec: Codec[A])(implicit signatureFactory: SignatureFactory): Codec[A] =
+  def variableSizeSignature[A](size: Codec[Int])(codec: Codec[A])(implicit signatureFactory: SignerFactory): Codec[A] =
     new SignatureCodec(codec, variableSizeBytes(size, BitVectorCodec))(signatureFactory)
 
   /**

--- a/src/test/scala/scodec/codecs/FletcherChecksumTest.scala
+++ b/src/test/scala/scodec/codecs/FletcherChecksumTest.scala
@@ -1,0 +1,55 @@
+package scodec.codecs
+
+import org.scalacheck._
+import org.scalatest.WordSpec
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
+import scodec.bits.ByteVector
+
+/**
+ * Test the Fletcher checksum functionality
+ *
+ */
+class FletcherChecksumTest extends WordSpec with GeneratorDrivenPropertyChecks {
+
+  "fletcher16 checksum" should {
+    /**
+     *  http://en.wikipedia.org/wiki/Fletcher's_checksum
+     *
+     *  "Example calculation of the Fletcher-16 checksum"
+     *
+     */
+    "wikipedia" in {
+      val signer = ChecksumFactory.fletcher16.newSigner
+      signer.update(Array(0x01, 0x02))
+      assert(signer.verify(Array(0x04, 0x03)))
+    }
+
+    "0xAA * (3N+2) => Array(0x0,0x55)" in {
+      forAll(Gen.posNum[Int]) { (n: Int) =>
+        pattern(n, 2,
+          Array(0x0, 0x55))
+      }
+    }
+
+    "0xAA * (3N + 1) => Array(0xAA, 0xAA)" in {
+      forAll(Gen.posNum[Int]) { (n: Int) =>
+        pattern(n, 1,
+          Array(0xAA.asInstanceOf[Byte], 0xAA.asInstanceOf[Byte]))
+      }
+    }
+
+    "0xAA * (3N) => Array(0x0, 0x0)" in {
+      forAll(Gen.posNum[Int]) { (n: Int) =>
+        pattern(n, 0,
+          Array(0x0, 0x0))
+      }
+    }
+  }
+
+  private def pattern(n: Int, delta: Int, expected: Array[Byte]): Unit = {
+    val signer = ChecksumFactory.fletcher16.newSigner
+    signer.update(ByteVector.fill(3 * n + delta)(0xAA).toArray)
+    assert(signer.verify(expected))
+  }
+
+}

--- a/src/test/scala/scodec/codecs/SignatureCodecTest.scala
+++ b/src/test/scala/scodec/codecs/SignatureCodecTest.scala
@@ -2,6 +2,7 @@ package scodec
 package codecs
 
 import java.security.KeyPairGenerator
+import java.util.Arrays
 
 class SignatureCodecTest extends CodecSuite {
 
@@ -13,7 +14,23 @@ class SignatureCodecTest extends CodecSuite {
 
   "fixedSizeSignature codec" should {
     "roundtrip using SHA256withRSA" in {
-      testFixedSizeSignature(SignatureFactory("SHA256withRSA", keyPair))
+      testFixedSizeSignature(1024/8)(SignatureFactory("SHA256withRSA", keyPair))
+    }
+    
+    "roundtrip using MD5" in {
+      testFixedSizeSignature(16)(ChecksumFactory.digest("MD5"))
+    }
+    
+    "roundtrip using Fletcher" in {
+      testFixedSizeSignature(2)(ChecksumFactory.fletcher16)
+    }
+    
+    "roundtrip using crc32" in {
+      testFixedSizeSignature(4)(ChecksumFactory.crc32)
+    }
+    
+     "roundtrip using adler32" in {
+      testFixedSizeSignature(4)(ChecksumFactory.adler32)
     }
   }
 
@@ -22,14 +39,22 @@ class SignatureCodecTest extends CodecSuite {
       testVariableSizeSignature(SignatureFactory("SHA256withRSA", keyPair))
     }
   }
+  
+  "variableSizeSignature codec" should {
+    "roundtrip using MD5" in {
+      testVariableSizeSignature(ChecksumFactory.digest("MD5"))
+    }
+  }
 
-  protected def testFixedSizeSignature(implicit sf: SignatureFactory) {
-    val codec = fixedSizeSignature(1024/8) { int32 ~ variableSizeBytes(int32, utf8) }
+  protected def testFixedSizeSignature(size:Int)(implicit sf: SignerFactory) {
+    val codec = fixedSizeSignature(size) { int32 ~ variableSizeBytes(int32, utf8) }
     forAll { (n: Int, s: String, x: Int) => roundtrip(codec, n ~ s) }
   }
 
-  protected def testVariableSizeSignature(implicit sf: SignatureFactory) {
+  protected def testVariableSizeSignature(implicit sf: SignerFactory) {
     val codec = variableSizeSignature(uint16) { int32 ~ variableSizeBytes(int32, utf8) } ~ int32
     forAll { (n: Int, s: String, x: Int) => roundtrip(codec, n ~ s ~ x) }
   }
+  
+ 
 }


### PR DESCRIPTION
- Replace usage of java.security.Signature with trait `Signer`, that delegates to Signature
- add Digest, CRC32 and Adler32 from Java API
- add Fletcher16 checksum (specific for my use case)
