### PR TITLE
remove the variance annotations on Encoder / Decoder

### DIFF
--- a/src/main/scala/scodec/Decoder.scala
+++ b/src/main/scala/scodec/Decoder.scala
@@ -19,7 +19,7 @@ import scodec.bits.BitVector
  * @groupname coproduct Coproduct Support
  * @groupprio coproduct 13
  */
-trait Decoder[+A] { self =>
+trait Decoder[A] { self =>
 
   /**
    * Attempts to decode a value of type `A` from the specified bit vector.

--- a/src/main/scala/scodec/Encoder.scala
+++ b/src/main/scala/scodec/Encoder.scala
@@ -19,7 +19,7 @@ import scodec.bits.BitVector
  * @groupname coproduct Coproduct Support
  * @groupprio coproduct 13
  */
-trait Encoder[-A] { self =>
+trait Encoder[A] { self =>
 
   /**
    * Attempts to encode the specified value in to a bit vector.

--- a/src/main/scala/scodec/GenCodec.scala
+++ b/src/main/scala/scodec/GenCodec.scala
@@ -5,7 +5,7 @@ import scalaz.{ \/, Profunctor }
 import scodec.bits.BitVector
 
 /** Generalized codec that allows the type to encode to vary from the type to decode. */
-trait GenCodec[-A, +B] extends Encoder[A] with Decoder[B] { self =>
+trait GenCodec[A, B] extends Encoder[A] with Decoder[B] { self =>
 
   /** Converts this `GenCodec` to a `GenCodec[A, C]` using the supplied `B => C`. */
   override def map[C](f: B => C): GenCodec[A, C] = GenCodec(this, super.map(f))


### PR DESCRIPTION
I realize this might be a controversial change. I don't know how widely people
are taking advantage of the variance on these types. We have found that the
variance can cause problems in implicit search.  Here's a minimal example that
demonstrates some of the problems we have been having:

```
import scodec.{Decoder, Codec, codecs}
import scala.collection.immutable.{IndexedSeq}

object Foo {
//  implicit val int32 = codecs.int32
  implicit def indexedSeq[A:Codec]: Codec[IndexedSeq[A]] =
    codecs.variableSizeBytes(codecs.int32, codecs.repeated(Codec[A]))
  val x = implicitly[Decoder[IndexedSeq[Int]]]
}
```

When trying to compile this with variance in place, the error we get is:

```
diverging implicit expansion for type scodec.Decoder[scala.collection.immutable.IndexedSeq[Int]]
```

The implicit should not be found in this case because of the missing int32
implicit. With the variance annotations removed we correctly get an implicit
not found. While this is not the end of the world, we have more complex
examples where an implicit should be found, but the variance gets us diverging
implicits.
