### PR TITLE
Change error type from String to scodec.Err

### DIFF
--- a/src/main/scala/scodec/DecodingContext.scala
+++ b/src/main/scala/scodec/DecodingContext.scala
@@ -7,16 +7,16 @@ import scodec.bits.BitVector
 /** Provides constructors for `DecodingContext`. */
 object DecodingContext {
 
-  /** Lifts a function of the shape `BitVector => String \/ (BitVector, A)` to a decoding context. */
-  def apply[A](f: BitVector => String \/ (BitVector, A)): DecodingContext[A] =
-    StateT[({type λ[+a] = String \/ a})#λ, BitVector, A](f)
+  /** Lifts a function of the shape `BitVector => Err \/ (BitVector, A)` to a decoding context. */
+  def apply[A](f: BitVector => Err \/ (BitVector, A)): DecodingContext[A] =
+    StateT[({type λ[+a] = Err \/ a})#λ, BitVector, A](f)
 
-  /** Lifts a value of `String \/ A` in to a decoding context. */
-  def liftE[A](e: String \/ A): DecodingContext[A] =
+  /** Lifts a value of `Err \/ A` in to a decoding context. */
+  def liftE[A](e: Err \/ A): DecodingContext[A] =
     apply { bv => e map { a => (bv, a) } }
 
   /** Provides a `MonadState` instance for `DecodingContext`. */
-  def monadState = StateT.stateTMonadState[BitVector, ({type λ[+a] = String \/ a})#λ]
+  def monadState = StateT.stateTMonadState[BitVector, ({type λ[+a] = Err \/ a})#λ]
 }
 
 

--- a/src/main/scala/scodec/Err.scala
+++ b/src/main/scala/scodec/Err.scala
@@ -1,0 +1,49 @@
+package scodec
+
+/**
+ * Describes an error.
+ *
+ * An error has a message and a list of context identifiers that provide insight into where an error occurs in a large structure.
+ *
+ * This type is not sealed so that codecs can return domain specific
+ * subtypes and dispatch on those subtypes.
+ */
+trait Err {
+
+  /** Gets a description of the error. */
+  def message: String
+
+  /**
+   * Gets a stack of context identifiers.
+   *
+   * The head of the list is the outermost (i.e., least specific) identifier.
+   */
+  def context: List[String]
+
+  /** Gets a description of the error with the context identifiers prefixing the message. */
+  def messageWithContext: String =
+    (if (context.isEmpty) "" else context.mkString("", "/", ": ")) + message
+
+  /** Returns a new error with the specified context identifier pushed in to the context stack. */
+  def pushContext(ctx: String): Err
+
+  override def toString = messageWithContext
+}
+
+/** Companion for [[Err]]. */
+object Err {
+
+  case class General(message: String, context: List[String]) extends Err {
+    def this(message: String) = this(message, Nil)
+    def pushContext(ctx: String) = copy(context = ctx :: context)
+  }
+
+  case class InsufficientBits(needed: Long, have: Long, context: List[String]) extends Err {
+    def this(needed: Long, have: Long) = this(needed, have, Nil)
+    def message = s"cannot acquire $needed bits from a vector that contains $have bits"
+    def pushContext(ctx: String) = copy(context = ctx :: context)
+  }
+
+  def apply(message: String): Err = new General(message)
+  def insufficientBits(needed: Long, have: Long): Err = new InsufficientBits(needed, have)
+}

--- a/src/main/scala/scodec/GenCodec.scala
+++ b/src/main/scala/scodec/GenCodec.scala
@@ -10,8 +10,8 @@ trait GenCodec[-A, +B] extends Encoder[A] with Decoder[B] { self =>
   /** Converts this `GenCodec` to a `GenCodec[A, C]` using the supplied `B => C`. */
   override def map[C](f: B => C): GenCodec[A, C] = GenCodec(this, super.map(f))
 
-  /** Converts this `GenCodec` to a `GenCodec[A, C]` using the supplied `B => String \/ C`. */
-  override def emap[C](f: B => String \/ C): GenCodec[A, C] = GenCodec(this, super.emap(f))
+  /** Converts this `GenCodec` to a `GenCodec[A, C]` using the supplied `B => Err \/ C`. */
+  override def emap[C](f: B => Err \/ C): GenCodec[A, C] = GenCodec(this, super.emap(f))
 
   /** Converts this `GenCodec` to a `GenCodec[C, B]` using the supplied `C => A`. */
   override def contramap[C](f: C => A): GenCodec[C, B] = GenCodec(super.contramap(f), this)
@@ -23,8 +23,8 @@ trait GenCodec[-A, +B] extends Encoder[A] with Decoder[B] { self =>
    */
   override def pcontramap[C](f: C => Option[A]): GenCodec[C, B] = GenCodec(super.pcontramap(f), this)
 
-  /** Converts this `GenCodec` to a `GenCodec[C, B]` using the supplied `C => String \/ A`. */
-  override def econtramap[C](f: C => String \/ A): GenCodec[C, B] = GenCodec(super.econtramap(f), this)
+  /** Converts this `GenCodec` to a `GenCodec[C, B]` using the supplied `C => Err \/ A`. */
+  override def econtramap[C](f: C => Err \/ A): GenCodec[C, B] = GenCodec(super.econtramap(f), this)
 
   /**
    * Converts this generalized codec in to a non-generalized codec assuming `A` and `B` are the same type.

--- a/src/main/scala/scodec/codecs/BooleanCodec.scala
+++ b/src/main/scala/scodec/codecs/BooleanCodec.scala
@@ -13,7 +13,7 @@ private[codecs] object BooleanCodec extends Codec[Boolean] {
 
   override def decode(buffer: BitVector) =
     buffer.acquire(1) match {
-      case Left(e) => \/.left(e)
+      case Left(e) => \/.left(Err.insufficientBits(1, 0))
       case Right(b) => \/.right((buffer.tail, b.head))
     }
 

--- a/src/main/scala/scodec/codecs/ByteCodec.scala
+++ b/src/main/scala/scodec/codecs/ByteCodec.scala
@@ -20,9 +20,9 @@ private[codecs] final class ByteCodec(bits: Int, signed: Boolean) extends Codec[
 
   override def encode(b: Byte) = {
     if (b > MaxValue) {
-      \/.left(s"$b is greater than maximum value $MaxValue for $description")
+      \/.left(Err(s"$b is greater than maximum value $MaxValue for $description"))
     } else if (b < MinValue) {
-      \/.left(s"$b is less than minimum value $MinValue for $description")
+      \/.left(Err(s"$b is less than minimum value $MinValue for $description"))
     } else {
       \/.right(BitVector.fromByte(b, bits))
     }
@@ -30,7 +30,7 @@ private[codecs] final class ByteCodec(bits: Int, signed: Boolean) extends Codec[
 
   override def decode(buffer: BitVector) =
     buffer.acquire(bits) match {
-      case Left(e) => \/.left(e)
+      case Left(e) => \/.left(Err.insufficientBits(bits, buffer.size))
       case Right(b) => \/.right((buffer.drop(bits), b.toByte(signed)))
     }
 

--- a/src/main/scala/scodec/codecs/CertificateCodec.scala
+++ b/src/main/scala/scodec/codecs/CertificateCodec.scala
@@ -22,7 +22,7 @@ private[codecs] final class CertificateCodec(certType: String) extends Codec[Cer
       \/-((BitVector.empty, cert))
     } catch {
       case e: CertificateException =>
-        -\/("Failed to decode certificate: " + e.getMessage)
+        -\/(Err("Failed to decode certificate: " + e.getMessage))
     }
   }
 

--- a/src/main/scala/scodec/codecs/ConditionalCodec.scala
+++ b/src/main/scala/scodec/codecs/ConditionalCodec.scala
@@ -10,7 +10,7 @@ import scodec.bits.BitVector
 private[codecs] final class ConditionalCodec[A](included: Boolean, codec: Codec[A]) extends Codec[Option[A]] {
 
   override def encode(a: Option[A]) = {
-    a.filter { _ => included }.fold(BitVector.empty.right[String]) { a => codec.encode(a) }
+    a.filter { _ => included }.fold(BitVector.empty.right[Err]) { a => codec.encode(a) }
   }
 
   override def decode(buffer: BitVector) = {

--- a/src/main/scala/scodec/codecs/ConstantCodec.scala
+++ b/src/main/scala/scodec/codecs/ConstantCodec.scala
@@ -14,9 +14,9 @@ private[codecs] final class ConstantCodec(constant: BitVector, validate: Boolean
   override def decode(buffer: BitVector) =
     if (validate) {
       buffer.acquire(constant.size) match {
-        case Left(e) => \/.left(e)
+        case Left(e) => \/.left(Err.insufficientBits(constant.size, buffer.size))
         case Right(b) =>
-          if (b == constant) \/.right((buffer.drop(constant.size), ())) else \/.left(s"expected constant $constant but got $b")
+          if (b == constant) \/.right((buffer.drop(constant.size), ())) else \/.left(Err(s"expected constant $constant but got $b"))
       }
     } else \/.right((buffer drop constant.size, ()))
 

--- a/src/main/scala/scodec/codecs/DoubleCodec.scala
+++ b/src/main/scala/scodec/codecs/DoubleCodec.scala
@@ -19,7 +19,7 @@ private[codecs] final class DoubleCodec(ordering: ByteOrdering) extends Codec[Do
 
   override def decode(buffer: BitVector) =
     buffer.acquire(64) match {
-      case Left(e) => \/.left(e)
+      case Left(e) => \/.left(Err.insufficientBits(64, buffer.size))
       case Right(b) => \/.right((buffer.drop(64), ByteBuffer.wrap(b.toByteArray).order(byteOrder).getDouble))
     }
 }

--- a/src/main/scala/scodec/codecs/FailCodec.scala
+++ b/src/main/scala/scodec/codecs/FailCodec.scala
@@ -5,11 +5,11 @@ import scalaz.\/
 
 import scodec.bits.BitVector
 
-private[codecs] final class FailCodec[A](encMessage: String, decMessage: String) extends Codec[A] {
+private[codecs] final class FailCodec[A](encErr: Err, decErr: Err) extends Codec[A] {
 
-  override def encode(a: A) = \/.left(encMessage)
+  override def encode(a: A) = \/.left(encErr)
 
-  override def decode(b: BitVector) = \/.left(decMessage)
+  override def decode(b: BitVector) = \/.left(encErr)
 
   override def toString = "fail"
 }

--- a/src/main/scala/scodec/codecs/FixedSizeCodec.scala
+++ b/src/main/scala/scodec/codecs/FixedSizeCodec.scala
@@ -12,7 +12,7 @@ private[codecs] final class FixedSizeCodec[A](size: Long, codec: Codec[A]) exten
     encoded <- codec.encode(a)
     result <- {
       if (encoded.size > size)
-        \/.left(s"[$a] requires ${encoded.size} bits but field is fixed size of $size bits")
+        \/.left(Err(s"[$a] requires ${encoded.size} bits but field is fixed size of $size bits"))
       else
         \/.right(encoded.padTo(size))
     }
@@ -20,7 +20,7 @@ private[codecs] final class FixedSizeCodec[A](size: Long, codec: Codec[A]) exten
 
   override def decode(buffer: BitVector) =
     buffer.acquire(size) match {
-      case Left(e) => \/.left(e)
+      case Left(e) => \/.left(Err.insufficientBits(size, buffer.size))
       case Right(b) =>
         codec.decode(b) match {
           case e @ -\/(_) => e

--- a/src/main/scala/scodec/codecs/FloatCodec.scala
+++ b/src/main/scala/scodec/codecs/FloatCodec.scala
@@ -19,7 +19,7 @@ private[codecs] final class FloatCodec(ordering: ByteOrdering) extends Codec[Flo
 
   override def decode(buffer: BitVector) =
     buffer.acquire(32) match {
-      case Left(e) => \/.left(e)
+      case Left(e) => \/.left(Err.insufficientBits(32, buffer.size))
       case Right(b) => \/.right((buffer.drop(32), ByteBuffer.wrap(b.toByteArray).order(byteOrder).getFloat))
     }
 }

--- a/src/main/scala/scodec/codecs/IgnoreCodec.scala
+++ b/src/main/scala/scodec/codecs/IgnoreCodec.scala
@@ -13,7 +13,7 @@ private[codecs] final class IgnoreCodec(bits: Long) extends Codec[Unit] {
 
   override def decode(buffer: BitVector) =
     buffer.acquire(bits) match {
-      case Left(e) => \/.left(e)
+      case Left(e) => \/.left(Err.insufficientBits(bits, buffer.size))
       case Right(_) => \/.right((buffer.drop(bits), ()))
     }
 

--- a/src/main/scala/scodec/codecs/IntCodec.scala
+++ b/src/main/scala/scodec/codecs/IntCodec.scala
@@ -20,9 +20,9 @@ private[codecs] final class IntCodec(bits: Int, signed: Boolean, ordering: ByteO
 
   override def encode(i: Int) = {
     if (i > MaxValue) {
-      \/.left(s"$i is greater than maximum value $MaxValue for $description")
+      \/.left(Err(s"$i is greater than maximum value $MaxValue for $description"))
     } else if (i < MinValue) {
-      \/.left(s"$i is less than minimum value $MinValue for $description")
+      \/.left(Err(s"$i is less than minimum value $MinValue for $description"))
     } else {
       \/.right(BitVector.fromInt(i, bits, ordering))
     }
@@ -30,7 +30,7 @@ private[codecs] final class IntCodec(bits: Int, signed: Boolean, ordering: ByteO
 
   override def decode(buffer: BitVector) =
     buffer.acquire(bits) match {
-      case Left(e) => \/.left(e)
+      case Left(e) => \/.left(Err.insufficientBits(bits, buffer.size))
       case Right(b) => \/.right((buffer.drop(bits), b.toInt(signed, ordering)))
     }
 

--- a/src/main/scala/scodec/codecs/ListCodec.scala
+++ b/src/main/scala/scodec/codecs/ListCodec.scala
@@ -7,9 +7,9 @@ import scodec.bits.BitVector
 
 private[codecs] final class ListCodec[A](codec: Codec[A], limit: Option[Int] = None) extends Codec[List[A]] {
 
-  def encode(list: List[A]): String \/ BitVector = Encoder.encodeSeq(codec)(list)
+  def encode(list: List[A]): Err \/ BitVector = Encoder.encodeSeq(codec)(list)
 
-  def decode(buffer: BitVector): String \/ (BitVector, List[A]) =
+  def decode(buffer: BitVector): Err \/ (BitVector, List[A]) =
     Decoder.decodeCollect[List, A](codec, limit)(buffer)
 
   override def toString = s"list($codec)"

--- a/src/main/scala/scodec/codecs/LongCodec.scala
+++ b/src/main/scala/scodec/codecs/LongCodec.scala
@@ -20,9 +20,9 @@ private[codecs] final class LongCodec(bits: Int, signed: Boolean, ordering: Byte
 
   override def encode(i: Long) = {
     if (i > MaxValue) {
-      \/.left(s"$i is greater than maximum value $MaxValue for $description")
+      \/.left(Err(s"$i is greater than maximum value $MaxValue for $description"))
     } else if (i < MinValue) {
-      \/.left(s"$i is less than minimum value $MinValue for $description")
+      \/.left(Err(s"$i is less than minimum value $MinValue for $description"))
     } else {
       \/.right(BitVector.fromLong(i, bits, ordering))
     }
@@ -30,7 +30,7 @@ private[codecs] final class LongCodec(bits: Int, signed: Boolean, ordering: Byte
 
   override def decode(buffer: BitVector) =
     buffer.acquire(bits) match {
-      case Left(e) => \/.left(e)
+      case Left(e) => \/.left(Err.insufficientBits(bits, buffer.size))
       case Right(b) => \/.right((buffer.drop(bits), b.toLong(signed, ordering)))
     }
 

--- a/src/main/scala/scodec/codecs/NamedCodec.scala
+++ b/src/main/scala/scodec/codecs/NamedCodec.scala
@@ -7,10 +7,10 @@ import scodec.bits.BitVector
 private[codecs] final class NamedCodec[A](name: String, target: Codec[A]) extends Codec[A] {
 
   override def encode(a: A) =
-    target.encode(a).leftMap { e => s"$name: $e" }
+    target.encode(a).leftMap { _ pushContext name }
 
   override def decode(buffer: BitVector) =
-    target.decode(buffer).leftMap { e => s"$name: $e" }
+    target.decode(buffer).leftMap { _ pushContext name }
 
   override def toString = s"$name($target)"
 }

--- a/src/main/scala/scodec/codecs/RecoverCodec.scala
+++ b/src/main/scala/scodec/codecs/RecoverCodec.scala
@@ -6,10 +6,10 @@ import scodec.bits.BitVector
 
 private[codecs] final class RecoverCodec(target: Codec[Unit], lookahead: Boolean) extends Codec[Boolean] {
 
-  def encode(a: Boolean): String \/ BitVector =
+  def encode(a: Boolean): Err \/ BitVector =
     target.encode(())
 
-  def decode(buffer: BitVector): String \/ (BitVector, Boolean) = {
+  def decode(buffer: BitVector): Err \/ (BitVector, Boolean) = {
     target.decode(buffer) match {
       case \/-((rest, _)) => \/-((if (lookahead) buffer else rest, true))
       case -\/(_) => \/-((buffer, false))

--- a/src/main/scala/scodec/codecs/ShortCodec.scala
+++ b/src/main/scala/scodec/codecs/ShortCodec.scala
@@ -20,9 +20,9 @@ private[codecs] final class ShortCodec(bits: Int, signed: Boolean, ordering: Byt
 
   override def encode(s: Short) = {
     if (s > MaxValue) {
-      \/.left(s"$s is greater than maximum value $MaxValue for $description")
+      \/.left(Err(s"$s is greater than maximum value $MaxValue for $description"))
     } else if (s < MinValue) {
-      \/.left(s"$s is less than minimum value $MinValue for $description")
+      \/.left(Err(s"$s is less than minimum value $MinValue for $description"))
     } else {
       \/.right(BitVector.fromShort(s, bits, ordering))
     }
@@ -30,7 +30,7 @@ private[codecs] final class ShortCodec(bits: Int, signed: Boolean, ordering: Byt
 
   override def decode(buffer: BitVector) =
     buffer.acquire(bits) match {
-      case Left(e) => \/.left(e)
+      case Left(e) => \/.left(Err.insufficientBits(bits, buffer.size))
       case Right(b) => \/.right((buffer.drop(bits), b.toShort(signed, ordering)))
     }
 

--- a/src/main/scala/scodec/codecs/StringCodec.scala
+++ b/src/main/scala/scodec/codecs/StringCodec.scala
@@ -17,7 +17,7 @@ private[codecs] final class StringCodec(charset: Charset) extends Codec[String] 
     try \/.right(BitVector(encoder.encode(buffer)))
     catch {
       case (_: MalformedInputException | _: UnmappableCharacterException) =>
-        \/.left(s"${charset.displayName} cannot encode character '${buffer.charAt(0)}'")
+        \/.left(Err(s"${charset.displayName} cannot encode character '${buffer.charAt(0)}'"))
     }
   }
 
@@ -27,7 +27,7 @@ private[codecs] final class StringCodec(charset: Charset) extends Codec[String] 
       \/.right((BitVector.empty, decoder.decode(buffer.toByteBuffer).toString))
     } catch {
       case (_: MalformedInputException | _: UnmappableCharacterException) =>
-        \/.left(s"${charset.displayName} cannot decode string from '0x${buffer.toByteVector.toHex}'")
+        \/.left(Err(s"${charset.displayName} cannot decode string from '0x${buffer.toByteVector.toHex}'"))
     }
   }
 

--- a/src/main/scala/scodec/codecs/VectorCodec.scala
+++ b/src/main/scala/scodec/codecs/VectorCodec.scala
@@ -7,9 +7,9 @@ import scodec.bits.BitVector
 
 private[codecs] final class VectorCodec[A](codec: Codec[A], limit: Option[Int] = None) extends Codec[Vector[A]] {
 
-  def encode(vector: Vector[A]): String \/ BitVector = Encoder.encodeSeq(codec)(vector)
+  def encode(vector: Vector[A]): Err \/ BitVector = Encoder.encodeSeq(codec)(vector)
 
-  def decode(buffer: BitVector): String \/ (BitVector, Vector[A]) =
+  def decode(buffer: BitVector): Err \/ (BitVector, Vector[A]) =
     Decoder.decodeCollect[Vector, A](codec, limit)(buffer)
 
   override def toString = s"vector($codec)"

--- a/src/main/scala/scodec/codecs/package.scala
+++ b/src/main/scala/scodec/codecs/package.scala
@@ -893,14 +893,14 @@ package object codecs {
    *
    * @group combinators
    */
-  def fail[A](message: String): Codec[A] = fail(message, message)
+  def fail[A](err: Err): Codec[A] = fail(err, err)
 
   /**
    * Codec that always fails encoding and decoding with the specified messages.
    *
    * @group combinators
    */
-  def fail[A](encMessage: String, decMessage: String): Codec[A] = new FailCodec[A](encMessage, decMessage)
+  def fail[A](encErr: Err, decErr: Err): Codec[A] = new FailCodec[A](encErr, decErr)
 
   /**
    * Codec that encrypts and decrypts using a `javax.crypto.Cipher`.

--- a/src/main/scala/scodec/package.scala
+++ b/src/main/scala/scodec/package.scala
@@ -34,7 +34,7 @@ import scodec.bits._
 package object scodec {
 
   /** Alias for state/either transformer that simplifies calling decode on a series of codecs, wiring the remaining bit vector of each in to the next entry. */
-  type DecodingContext[A] = StateT[({type λ[a] = String \/ a})#λ, BitVector, A]
+  type DecodingContext[A] = StateT[({type λ[a] = Err \/ a})#λ, BitVector, A]
 
   implicit val bitVectorMonoidInstance: Monoid[BitVector] = Monoid.instance(_ ++ _, BitVector.empty)
 

--- a/src/test/scala/scodec/CodecTest.scala
+++ b/src/test/scala/scodec/CodecTest.scala
@@ -19,8 +19,8 @@ class CodecTest extends CodecSuite {
     "support complete combinator" in {
       val codec = codecs.bits(8)
       codec.decode(hex"00112233".toBitVector) shouldBe \/.right((hex"112233".toBitVector, hex"00".toBitVector))
-      codec.complete.decode(hex"00112233".toBitVector) shouldBe \/.left("24 bits remaining: 0x112233")
-      codec.complete.decode(BitVector.fill(2000)(false)) shouldBe \/.left("more than 512 bits remaining")
+      codec.complete.decode(hex"00112233".toBitVector) shouldBe \/.left(Err("24 bits remaining: 0x112233"))
+      codec.complete.decode(BitVector.fill(2000)(false)) shouldBe \/.left(Err("more than 512 bits remaining"))
     }
 
     "support as method for converting to a new codec using implicit isomorphism," which {
@@ -73,14 +73,14 @@ class CodecTest extends CodecSuite {
     "support validating input and output" in {
       // accept 8 bit values no greater than 9
       val oneDigit: Codec[Int] = uint8.exmap[Int](
-        v => if (v > 9) -\/("badv") else \/-(v),
-        d => if (d > 9) -\/("badd") else \/-(d))
+        v => if (v > 9) -\/(Err("badv")) else \/-(v),
+        d => if (d > 9) -\/(Err("badd")) else \/-(d))
 
       oneDigit.encode(3) shouldBe \/-(BitVector(0x03))
-      oneDigit.encode(10) shouldBe -\/("badd")
-      oneDigit.encode(30000000) shouldBe -\/("badd")
+      oneDigit.encode(10) shouldBe -\/(Err("badd"))
+      oneDigit.encode(30000000) shouldBe -\/(Err("badd"))
       oneDigit.decode(BitVector(0x05)) shouldBe \/-((BitVector.empty, 5))
-      oneDigit.decode(BitVector(0xff)) shouldBe -\/("badv")
+      oneDigit.decode(BitVector(0xff)) shouldBe -\/(Err("badv"))
       oneDigit.decode(BitVector.empty) shouldBe uint8.decode(BitVector.empty)
     }
 
@@ -93,7 +93,7 @@ class CodecTest extends CodecSuite {
   }
 
   def i2l(i: Int): Long = i.toLong
-  def l2i(l: Long): String \/ Int = if (l >= Int.MinValue && l <= Int.MaxValue) right(l.toShort) else left("out of range")
+  def l2i(l: Long): Err \/ Int = if (l >= Int.MinValue && l <= Int.MaxValue) right(l.toShort) else left(Err("out of range"))
 
   "narrow" should {
     "support converting to a smaller type" in {
@@ -109,27 +109,28 @@ class CodecTest extends CodecSuite {
         if (n >= Int.MinValue && n <= Int.MaxValue)
           narrowed.encode(n) shouldBe int32.encode(n.toInt)
         else
-          narrowed.encode(n) shouldBe left("out of range")
+          narrowed.encode(n) shouldBe left(Err("out of range"))
       }
     }
   }
-    "encodeOnly" should {
-      val char8: Codec[Char] = uint8.contramap[Char](_.toInt).encodeOnly
-      "encode works" which {
-        char8.encode('a') shouldBe \/-(BitVector(0x61))
-      }
-      "decode is rejected" which {
-        char8.decode(hex"61".bits) shouldBe -\/("decoding not supported")
-      }
+
+  "encodeOnly" should {
+    val char8: Codec[Char] = uint8.contramap[Char](_.toInt).encodeOnly
+    "encode works" which {
+      char8.encode('a') shouldBe \/-(BitVector(0x61))
     }
-    
-    "decodeOnly" should {
-      val char8: Codec[Char] = uint8.map[Char](_.asInstanceOf[Char]).decodeOnly
-      "decode works" which {
-        char8.decode(BitVector(0x61)) shouldBe \/-((BitVector.empty, 'a'))
-      }
-      "encode is rejected" which {
-        char8.encode('a') shouldBe -\/("encoding not supported")
-      }
+    "decode is rejected" which {
+      char8.decode(hex"61".bits) shouldBe -\/(Err("decoding not supported"))
     }
+  }
+
+  "decodeOnly" should {
+    val char8: Codec[Char] = uint8.map[Char](_.asInstanceOf[Char]).decodeOnly
+    "decode works" which {
+      char8.decode(BitVector(0x61)) shouldBe \/-((BitVector.empty, 'a'))
+    }
+    "encode is rejected" which {
+      char8.encode('a') shouldBe -\/(Err("encoding not supported"))
+    }
+  }
 }

--- a/src/test/scala/scodec/codecs/BooleanCodecTest.scala
+++ b/src/test/scala/scodec/codecs/BooleanCodecTest.scala
@@ -33,7 +33,7 @@ class BooleanCodecTest extends CodecSuite {
       bool(8).decode(bin"00000001") shouldBe \/.right((BitVector.empty, true))
     }
     "return an error when decoding with too few bits" in {
-      bool(8).decode(BitVector.low(4)) shouldBe \/.left("cannot acquire 8 bits from a vector that contains 4 bits")
+      bool(8).decode(BitVector.low(4)) shouldBe \/.left(Err.insufficientBits(8, 4))
     }
   }
 }

--- a/src/test/scala/scodec/codecs/ByteCodecTest.scala
+++ b/src/test/scala/scodec/codecs/ByteCodecTest.scala
@@ -18,13 +18,13 @@ class ByteCodecTest extends CodecSuite {
 
   "the byte codecs" should {
     "return an error when value to encode is out of legal range" in {
-      byte(7).encode(Byte.MaxValue) shouldBe \/.left("127 is greater than maximum value 63 for 7-bit signed byte")
-      byte(7).encode(Byte.MinValue) shouldBe \/.left("-128 is less than minimum value -64 for 7-bit signed byte")
-      ubyte(7).encode(-1) shouldBe \/.left("-1 is less than minimum value 0 for 7-bit unsigned byte")
+      byte(7).encode(Byte.MaxValue) shouldBe \/.left(Err("127 is greater than maximum value 63 for 7-bit signed byte"))
+      byte(7).encode(Byte.MinValue) shouldBe \/.left(Err("-128 is less than minimum value -64 for 7-bit signed byte"))
+      ubyte(7).encode(-1) shouldBe \/.left(Err("-1 is less than minimum value 0 for 7-bit unsigned byte"))
     }
 
     "return an error when decoding with too few bits" in {
-      byte.decode(BitVector.low(4)) shouldBe \/.left("cannot acquire 8 bits from a vector that contains 4 bits")
+      byte.decode(BitVector.low(4)) shouldBe \/.left(Err.insufficientBits(8, 4))
     }
   }
 }

--- a/src/test/scala/scodec/codecs/DoubleCodecTest.scala
+++ b/src/test/scala/scodec/codecs/DoubleCodecTest.scala
@@ -19,7 +19,7 @@ class DoubleCodecTest extends CodecSuite {
     }
 
     "return an error when decoding with too few bits" in {
-      double.decode(BitVector.low(8)) shouldBe \/.left("cannot acquire 64 bits from a vector that contains 8 bits")
+      double.decode(BitVector.low(8)) shouldBe \/.left(Err.insufficientBits(64, 8))
     }
   }
 }

--- a/src/test/scala/scodec/codecs/FailCodecTest.scala
+++ b/src/test/scala/scodec/codecs/FailCodecTest.scala
@@ -9,22 +9,22 @@ import scodec.bits.BitVector
 class FailCodecTest extends CodecSuite {
 
   // The scalatest fail method shadows this
-  def fl[A](msg: String) = scodec.codecs.fail[A](msg)
+  def fl[A](e: Err) = scodec.codecs.fail[A](e)
 
   "the fail codec" should {
 
     "always fail encoding" in {
-      fl("err").encode(()) shouldBe 'left
+      fl(Err("err")).encode(()) shouldBe 'left
     }
 
     "always fail decoding" in {
-      fl("err").decode(BitVector.low(1024)) shouldBe 'left
+      fl(Err("err")).decode(BitVector.low(1024)) shouldBe 'left
     }
 
     "be useful" in {
-      val codec: Codec[(Int, String)] = int32 flatZip { x => if (x % 2 == 0) fixedSizeBytes(x / 2, ascii) else fl("must be even") }
+      val codec: Codec[(Int, String)] = int32 flatZip { x => if (x % 2 == 0) fixedSizeBytes(x / 2, ascii) else fl(Err("must be even")) }
       codec.encode((4, "Hi")) shouldBe 'right
-      codec.encode((1, "Hi")) shouldBe -\/("must be even")
+      codec.encode((1, "Hi")) shouldBe -\/(Err("must be even"))
     }
   }
 }

--- a/src/test/scala/scodec/codecs/FixedSizeCodecTest.scala
+++ b/src/test/scala/scodec/codecs/FixedSizeCodecTest.scala
@@ -13,7 +13,7 @@ class FixedSizeCodecTest extends CodecSuite {
       roundtrip(fixedSizeBits(8, uint8), 12)
       roundtrip(fixedSizeBits(16, uint8), 12)
     }
-    
+
      "pad appropriately" in {
       fixedSizeBits(16, uint8).encodeValid(12) shouldBe BitVector(hex"0c00")
     }
@@ -22,7 +22,7 @@ class FixedSizeCodecTest extends CodecSuite {
     "fail encoding when value is too large to be encoded by size codec" in {
       val encoded = ascii.encode("test").toOption.get
       fixedSizeBits(32, ascii).decode(encoded ++ BitVector.low(48)) shouldBe \/-((BitVector.low(48), "test"))
-      fixedSizeBits(24, ascii).encode("test") shouldBe -\/("[test] requires 32 bits but field is fixed size of 24 bits")
+      fixedSizeBits(24, ascii).encode("test") shouldBe -\/(Err("[test] requires 32 bits but field is fixed size of 24 bits"))
     }
   }
 }

--- a/src/test/scala/scodec/codecs/FloatCodecTest.scala
+++ b/src/test/scala/scodec/codecs/FloatCodecTest.scala
@@ -19,7 +19,7 @@ class FloatCodecTest extends CodecSuite {
     }
 
     "return an error when decoding with too few bits" in {
-      float.decode(BitVector.low(8)) shouldBe \/.left("cannot acquire 32 bits from a vector that contains 8 bits")
+      float.decode(BitVector.low(8)) shouldBe \/.left(Err.insufficientBits(32, 8))
     }
   }
 }

--- a/src/test/scala/scodec/codecs/IntCodecTest.scala
+++ b/src/test/scala/scodec/codecs/IntCodecTest.scala
@@ -40,19 +40,19 @@ class IntCodecTest extends CodecSuite {
         littleEndian shouldBe bigEndian.reverse
       }
       check(0, 15) { (n: Int) =>
-        val bigEndian = uint4.encode(n).valueOr(sys.error).toByteVector
-        val littleEndian = uint4L.encode(n).valueOr(sys.error).toByteVector
+        val bigEndian = uint4.encodeValid(n).toByteVector
+        val littleEndian = uint4L.encodeValid(n).toByteVector
         littleEndian shouldBe bigEndian.reverse
       }
       check(0, (1 << 24) - 1) { (n: Int) =>
-        val bigEndian = uint24.encode(n).valueOr(sys.error).toByteVector
-        val littleEndian = uint24L.encode(n).valueOr(sys.error).toByteVector
+        val bigEndian = uint24.encodeValid(n).toByteVector
+        val littleEndian = uint24L.encodeValid(n).toByteVector
         littleEndian shouldBe bigEndian.reverse
       }
       check(0, 8191) { (n: Int) =>
         whenever(n >= 0 && n <= 8191) {
-          val bigEndian = uint(13).encode(n).valueOr(sys.error)
-          val littleEndian = uintL(13).encode(n).valueOr(sys.error).toByteVector
+          val bigEndian = uint(13).encodeValid(n)
+          val littleEndian = uintL(13).encodeValid(n).toByteVector
           val flipped = BitVector(littleEndian.last).take(5) ++ littleEndian.init.reverse.toBitVector
           flipped shouldBe bigEndian
         }
@@ -60,13 +60,13 @@ class IntCodecTest extends CodecSuite {
     }
 
     "return an error when value to encode is out of legal range" in {
-      int16.encode(65536) shouldBe \/.left("65536 is greater than maximum value 32767 for 16-bit signed integer")
-      int16.encode(-32769) shouldBe \/.left("-32769 is less than minimum value -32768 for 16-bit signed integer")
-      uint16.encode(-1) shouldBe \/.left("-1 is less than minimum value 0 for 16-bit unsigned integer")
+      int16.encode(65536) shouldBe \/.left(Err("65536 is greater than maximum value 32767 for 16-bit signed integer"))
+      int16.encode(-32769) shouldBe \/.left(Err("-32769 is less than minimum value -32768 for 16-bit signed integer"))
+      uint16.encode(-1) shouldBe \/.left(Err("-1 is less than minimum value 0 for 16-bit unsigned integer"))
     }
 
     "return an error when decoding with too few bits" in {
-      int16.decode(BitVector.low(8)) shouldBe \/.left("cannot acquire 16 bits from a vector that contains 8 bits")
+      int16.decode(BitVector.low(8)) shouldBe \/.left(Err.insufficientBits(16, 8))
     }
   }
 }

--- a/src/test/scala/scodec/codecs/LongCodecTest.scala
+++ b/src/test/scala/scodec/codecs/LongCodecTest.scala
@@ -30,11 +30,11 @@ class LongCodecTest extends CodecSuite {
     }
 
     "return an error when value to encode is out of legal range" in {
-      uint32.encode(-1) shouldBe \/.left("-1 is less than minimum value 0 for 32-bit unsigned integer")
+      uint32.encode(-1) shouldBe \/.left(Err("-1 is less than minimum value 0 for 32-bit unsigned integer"))
     }
 
     "return an error when decoding with too few bits" in {
-      uint32.decode(BitVector.low(8)) shouldBe \/.left("cannot acquire 32 bits from a vector that contains 8 bits")
+      uint32.decode(BitVector.low(8)) shouldBe \/.left(Err.insufficientBits(32, 8))
     }
   }
 }

--- a/src/test/scala/scodec/codecs/PaddedFixedSizeCodecTest.scala
+++ b/src/test/scala/scodec/codecs/PaddedFixedSizeCodecTest.scala
@@ -22,11 +22,11 @@ class PaddedFixedSizeCodecTest extends CodecSuite {
     }
 
     "failed padCodec encode only reported if used" in {
-      paddedFixedSizeBytes(1, uint8, codecs.fail("bad pad")).encodeValid(12) shouldBe BitVector(hex"0c")
+      paddedFixedSizeBytes(1, uint8, codecs.fail(Err("bad pad"))).encodeValid(12) shouldBe BitVector(hex"0c")
     }
 
     "report failed padCodec encode" in {
-      paddedFixedSizeBytes(2, uint8, codecs.fail("bad pad")).encode(12) shouldBe -\/("Padding codec [fail] failed : bad pad")
+      paddedFixedSizeBytes(2, uint8, codecs.fail(Err("bad pad"))).encode(12) shouldBe -\/(Err("Padding codec [fail] failed: bad pad"))
     }
   }
 
@@ -44,8 +44,8 @@ class PaddedFixedSizeCodecTest extends CodecSuite {
     }
 
     "encode fails if padding does not exactly fill" in {
-      paddedFixedSizeBits(13, uint8, ones).encode(12) shouldBe -\/("[12] padded by [constant(BitVector(8 bits, 0xff))] overflows fixed size field of 13 bits")
-      paddedFixedSizeBits(27, uint8, ones).encode(12) shouldBe -\/("[12] padded by [constant(BitVector(8 bits, 0xff))] overflows fixed size field of 27 bits")
+      paddedFixedSizeBits(13, uint8, ones).encode(12) shouldBe -\/(Err("[12] padded by [constant(BitVector(8 bits, 0xff))] overflows fixed size field of 13 bits"))
+      paddedFixedSizeBits(27, uint8, ones).encode(12) shouldBe -\/(Err("[12] padded by [constant(BitVector(8 bits, 0xff))] overflows fixed size field of 27 bits"))
     }
 
     "decode validate remainder" in {
@@ -60,15 +60,15 @@ class PaddedFixedSizeCodecTest extends CodecSuite {
 
     "decode fails if remaining bits do not match pad" in {
       paddedFixedSizeBits(8, uint8, ones).decodeValidValue(BitVector(hex"0c")) shouldBe 12
-      paddedFixedSizeBits(9, uint8, ones).decode(BitVector(hex"0c00")) shouldBe -\/("cannot acquire 8 bits from a vector that contains 1 bits")
-      paddedFixedSizeBits(16, uint8, ones).decode(BitVector(hex"0c00")) shouldBe -\/("expected constant BitVector(8 bits, 0xff) but got BitVector(8 bits, 0x00)")
-      paddedFixedSizeBits(24, uint8, ones).decode(BitVector(hex"0cff11")) shouldBe -\/("expected constant BitVector(8 bits, 0xff) but got BitVector(8 bits, 0x11)")
+      paddedFixedSizeBits(9, uint8, ones).decode(BitVector(hex"0c00")) shouldBe -\/(Err.insufficientBits(8, 1))
+      paddedFixedSizeBits(16, uint8, ones).decode(BitVector(hex"0c00")) shouldBe -\/(Err("expected constant BitVector(8 bits, 0xff) but got BitVector(8 bits, 0x00)"))
+      paddedFixedSizeBits(24, uint8, ones).decode(BitVector(hex"0cff11")) shouldBe -\/(Err("expected constant BitVector(8 bits, 0xff) but got BitVector(8 bits, 0x11)"))
     }
 
     "fail encoding when value is too large to be encoded by size codec" in {
       val encoded = ascii.encode("test").toOption.get
       paddedFixedSizeBits(32, ascii, ones).decode(encoded ++ BitVector.low(48)) shouldBe \/-((BitVector.low(48), "test"))
-      paddedFixedSizeBits(24, ascii, ones).encode("test") shouldBe -\/("[test] requires 32 bits but field is fixed size of 24 bits")
+      paddedFixedSizeBits(24, ascii, ones).encode("test") shouldBe -\/(Err("[test] requires 32 bits but field is fixed size of 24 bits"))
     }
   }
 }

--- a/src/test/scala/scodec/codecs/ShortCodecTest.scala
+++ b/src/test/scala/scodec/codecs/ShortCodecTest.scala
@@ -27,8 +27,8 @@ class ShortCodecTest extends CodecSuite {
       }
       check(0, 8191) { (n: Short) =>
         whenever(n >= 0 && n <= 8191) {
-          val bigEndian = ushort(13).encode(n).valueOr(sys.error)
-          val littleEndian = ushortL(13).encode(n).valueOr(sys.error).toByteVector
+          val bigEndian = ushort(13).encodeValid(n)
+          val littleEndian = ushortL(13).encodeValid(n).toByteVector
           val flipped = BitVector(littleEndian.last).take(5) ++ littleEndian.init.reverse.toBitVector
           flipped shouldBe bigEndian
         }
@@ -36,13 +36,13 @@ class ShortCodecTest extends CodecSuite {
     }
 
     "return an error when value to encode is out of legal range" in {
-      short(15).encode(Short.MaxValue) shouldBe \/.left("32767 is greater than maximum value 16383 for 15-bit signed short")
-      short(15).encode(Short.MinValue) shouldBe \/.left("-32768 is less than minimum value -16384 for 15-bit signed short")
-      ushort(15).encode(-1) shouldBe \/.left("-1 is less than minimum value 0 for 15-bit unsigned short")
+      short(15).encode(Short.MaxValue) shouldBe \/.left(Err("32767 is greater than maximum value 16383 for 15-bit signed short"))
+      short(15).encode(Short.MinValue) shouldBe \/.left(Err("-32768 is less than minimum value -16384 for 15-bit signed short"))
+      ushort(15).encode(-1) shouldBe \/.left(Err("-1 is less than minimum value 0 for 15-bit unsigned short"))
     }
 
     "return an error when decoding with too few bits" in {
-      short16.decode(BitVector.low(8)) shouldBe \/.left("cannot acquire 16 bits from a vector that contains 8 bits")
+      short16.decode(BitVector.low(8)) shouldBe \/.left(Err.insufficientBits(16, 8))
     }
   }
 }

--- a/src/test/scala/scodec/codecs/StringCodecTest.scala
+++ b/src/test/scala/scodec/codecs/StringCodecTest.scala
@@ -20,12 +20,12 @@ class StringCodecTest extends CodecSuite {
 
   "string codecs" should {
     "fail encoding with an error when string to encode contains chars unsupported by charset" in {
-      ascii.encode("λ") shouldBe \/.left("US-ASCII cannot encode character 'λ'")
-      ascii.encode("Includes a λ") shouldBe \/.left("US-ASCII cannot encode character 'λ'")
+      ascii.encode("λ") shouldBe \/.left(Err("US-ASCII cannot encode character 'λ'"))
+      ascii.encode("Includes a λ") shouldBe \/.left(Err("US-ASCII cannot encode character 'λ'"))
     }
 
     "fail decoding with an error when buffer contains bytes unsupported by charset" in {
-      utf8.decode(BitVector(ByteVector.fromValidHex("0xf4ffffff"))) shouldBe \/.left("UTF-8 cannot decode string from '0xf4ffffff'")
+      utf8.decode(BitVector(ByteVector.fromValidHex("0xf4ffffff"))) shouldBe \/.left(Err("UTF-8 cannot decode string from '0xf4ffffff'"))
     }
   }
 }

--- a/src/test/scala/scodec/codecs/VariableSizeCodecTest.scala
+++ b/src/test/scala/scodec/codecs/VariableSizeCodecTest.scala
@@ -18,7 +18,7 @@ class VariableSizeCodecTest extends CodecSuite {
     }
 
     "fail encoding when value is too large to be encoded by size codec" in {
-      variableSizeBytes(uint2, ascii).encode("too long") shouldBe -\/("[too long] is too long to be encoded: 8 is greater than maximum value 3 for 2-bit unsigned integer")
+      variableSizeBytes(uint2, ascii).encode("too long") shouldBe -\/(Err("[too long] is too long to be encoded: 8 is greater than maximum value 3 for 2-bit unsigned integer"))
     }
 
     "support padding of size" in {


### PR DESCRIPTION
By using an open-for-extension type as the error type, codecs are free to return domain specific errors and clients of such codecs can then dispatch based on the error type received.

This PR defines 2 subtypes of `Err` -- `General`, which wraps a string, and `InsufficientBits`, which indicates a decoding failure occurred due to the buffer being undersized.

This breaks source compatibility, although migration is fairly painless:
- when returning errors, instead of returning a `left(string)`, return a `left(Err(string))`
- when working with the result of encoding/decoding, call `err.messageWithContext` to get an equivalent `String`

Due to source compatibility breakage, I'd like to hear feedback from folks before merging. All feedback is appreciated but I'm tagging a few folks that I know have opinions. @pchiusano @djspiewak @stew @runarorama @timperrett

Note: I've considered making the error type parametrized (i.e., `Encoder[A, E]`, `Decoder[A, E]`, `Codec[A, E]`) but I'm not convinced that the benefits of the generality outweigh the added complexity in usage -- especially with implicit lookup. Additionally, the impacts to source compatibility are much, much higher.
