### PR TITLE
Partially fixes #30

### DIFF
--- a/src/main/scala/scodec/Codec.scala
+++ b/src/main/scala/scodec/Codec.scala
@@ -445,10 +445,10 @@ object Codec extends EncoderFunctions with DecoderFunctions {
       def codec = auto.codec
     }
 
-    implicit def coproduct[A, D, C <: Coproduct, L <: HList](implicit
-      auto: CoproductAuto.Aux[A, C, L],
+    implicit def coproduct[A, D, C0 <: Coproduct](implicit
       discriminated: codecs.Discriminated[A, D],
-      auto2: codecs.CoproductBuilderAutoDiscriminators[A, C, D]
+      auto: CoproductAuto[A] { type C = C0 },
+      auto2: codecs.CoproductBuilderAutoDiscriminators[A, C0, D]
     ): Derive[A] = new Derive[A] {
       def codec = auto.apply.auto
     }

--- a/src/test/scala/scodec/examples/DerivedCodecExamples.scala
+++ b/src/test/scala/scodec/examples/DerivedCodecExamples.scala
@@ -25,7 +25,26 @@ class DerivedCodecsExample extends CodecSuite {
     implicit val discriminator: Discriminator[Sprocket, Wocket, Int] = Discriminator(2)
   }
 
+  case class Wootle(count: Int, data: BitVector) extends Sprocket
+  object Wootle {
+    implicit val discriminator: Discriminator[Sprocket, Wootle, Int] = Discriminator(3)
+    implicit val codec: Codec[Wootle] = (uint8 :: bits).as[Wootle]
+  }
+
   case class Geiling(name: String, sprockets: Vector[Sprocket])
+
+  sealed trait Color
+  object Color {
+    case object Red extends Color
+    case object Yellow extends Color
+    case object Green extends Color
+
+    implicit val codec: Codec[Color] = mappedEnum(uint8,
+      Red -> 0,
+      Yellow -> 1,
+      Green -> 2
+    )
+  }
 
   "derived codec examples" should {
 
@@ -60,6 +79,11 @@ class DerivedCodecsExample extends CodecSuite {
       Codec[Sprocket].encodeValid(Wocket(3, true)) shouldBe hex"020301".bits
     }
 
+    "demonstrate subtype overrides in companion" in {
+      // Alternatively, the overriden codec can be defined in the companion of the subtype.
+      Codec[Sprocket].encodeValid(Wootle(4, hex"deadbeef".bits)) shouldBe hex"0304deadbeef".bits
+    }
+
     "demonstrate nested derivations" in {
       // Derived codecs can be based on other derived codecs.
       //
@@ -71,6 +95,11 @@ class DerivedCodecsExample extends CodecSuite {
       val encoded = Codec[Geiling].encodeValid(ceil)
       encoded shouldBe hex"00000004 4365696c 00000002 010000000100000002 0200000003ff".bits
       Codec[Geiling].decodeValidValue(encoded) shouldBe ceil
+    }
+
+    "demonstrate that derivation support does not interfere with manually authored implicit codecs in companions" in {
+      //implicitly[Codec.CoproductAuto[Color]]
+      Codec[Color].encodeValid(Color.Green) shouldBe hex"02".bits
     }
   }
 }


### PR DESCRIPTION
Bail out of sealed trait codec derivation if there's no
`Discriminated[A, D]` in scope.
