### PR TITLE
Fixes #30

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ libraryDependencies ++= Seq(
   "org.scalaz" %% "scalaz-core" % "7.1.0",
   "com.chuusai" % "shapeless" % "2.0.0" cross CrossVersion.fullMapped {
     case "2.10.4" => "2.10.4"
-    case "2.11.0" => "2.11"
+    case x if x startsWith "2.11." => "2.11"
   },
   "org.scalatest" %% "scalatest" % "2.2.0" % "test",
   "org.scalacheck" %% "scalacheck" % "1.11.3" % "test",

--- a/src/main/scala/scodec/DerivedCodec.scala
+++ b/src/main/scala/scodec/DerivedCodec.scala
@@ -1,0 +1,71 @@
+package scodec
+
+import scala.language.implicitConversions
+import shapeless._
+import shapeless.record._
+import shapeless.ops.hlist._
+import shapeless.ops.record._
+import shapeless.syntax._
+
+/**
+ * Wrapper for a codec that was automatically derived.
+ *
+ * This type is not typically used directly. Rather, to get a derived codec,
+ * call `Codec.derive[A]`. This type is typically used as an implicit witness parameter.
+ *
+ * Codecs can be derived for:
+ *  - case classes, when each component type of the case has an implicitly available codec
+ *  - sealed class hierarchies, where:
+ *    - the root type, `A`, has an implicitly availble `Discriminated[A, D]` for some `D`
+ *    - each subtype has an implicitly available codec or can have one derived
+ *    - each subtype `X` has an implicitly available `Discriminator[A, X, D]`
+ *
+ * Instances of this type can be used directly as a `Codec[A]`. There is no need to manually unwrap by calling `d.codec`.
+ */
+@annotation.implicitNotFound("""Could not derive a codec automatically for ${A}. Support exists for case classes, where each component type has an implicit codec in scope, and for sealed class hierarchies, where there is an implicit Discriminated[${A}, D] and implicit Discriminators[${A}, X, D] for each subtype X of ${A}.""")
+sealed abstract class DerivedCodec[A] {
+  def codec: Codec[A]
+}
+
+/** Companion for [[DerivedCodec]]. */
+object DerivedCodec {
+
+  implicit def unwrap[A](dc: DerivedCodec[A]): Codec[A] = dc.codec
+
+  /** Derives a codec for the specified type. */
+  def apply[A](implicit dc: DerivedCodec[A]): DerivedCodec[A] = dc
+
+  implicit def hnil: DerivedCodec[HNil] =
+    new DerivedCodec[HNil] { val codec = codecs.HListCodec.hnilCodec }
+
+  implicit def hlist[H, T <: HList](implicit headCodec: ImplicitCodec[H], tailAux: DerivedCodec[T]): DerivedCodec[H :: T] =
+    new DerivedCodec[H :: T] { val codec = headCodec :: tailAux.codec }
+
+  implicit def record[KH <: Symbol, VH, TRec <: HList, KT <: HList](implicit
+    keys: Keys.Aux[FieldType[KH, VH] :: TRec, KH :: KT],
+    headCodec: ImplicitCodec[VH],
+    tailAux: DerivedCodec[TRec]
+  ): DerivedCodec[FieldType[KH, VH] :: TRec] = new DerivedCodec[FieldType[KH, VH] :: TRec] {
+    val codec = {
+      import codecs.StringEnrichedWithCodecNamingSupport
+      val namedHeadCodec: Codec[VH] = keys().head.name | headCodec
+      val headFieldCodec: Codec[FieldType[KH, VH]] = namedHeadCodec.toField[KH]
+      headFieldCodec :: tailAux.codec
+    }
+  }
+
+  implicit def labelledProduct[A, Rec <: HList](implicit
+    lgen: LabelledGeneric.Aux[A, Rec],
+    auto: DerivedCodec[Rec]
+  ): DerivedCodec[A] = new DerivedCodec[A] {
+    val codec = auto.codec.xmap(lgen.from, lgen.to)
+  }
+
+  implicit def coproduct[A, D, C0 <: Coproduct](implicit
+    discriminated: codecs.Discriminated[A, D],
+    auto: codecs.CoproductBuilderAuto[A] { type C = C0 },
+    auto2: codecs.CoproductBuilderAutoDiscriminators[A, C0, D]
+  ): DerivedCodec[A] = new DerivedCodec[A] {
+    def codec = auto.apply.auto
+  }
+}

--- a/src/main/scala/scodec/ImplicitCodec.scala
+++ b/src/main/scala/scodec/ImplicitCodec.scala
@@ -1,0 +1,31 @@
+package scodec
+
+import scala.language.implicitConversions
+
+/**
+ * Type class that supports implicit lookup of implicit `Codec` instances with a fallback to automatically derived codecs.
+ */
+@annotation.implicitNotFound("""Could not find an implicit Codec[${A}] and a codec could not be automatically derived. Derivation support exists for case classes, where each component type has an implicit codec in scope, and for sealed class hierarchies, where there is an implicit Discriminated[${A}, D] and implicit Discriminators[${A}, X, D] for each subtype X of ${A}.""")
+sealed abstract class ImplicitCodec[A] {
+  def codec: Codec[A]
+}
+
+/** Defines derived codecs as a fallback to regular implicit `Codec` instances. */
+sealed trait LowPriorityImplicitCodec {
+  implicit def derive[A](implicit d: DerivedCodec[A]): ImplicitCodec[A] = new ImplicitCodec[A] {
+    val codec = d.codec
+  }
+}
+
+/** Companion for [[ImplicitCodec]]. */
+object ImplicitCodec extends LowPriorityImplicitCodec {
+
+  implicit def unwrap[A](ic: ImplicitCodec[A]): Codec[A] = ic.codec
+
+  /** Gets the implicitly available codec for type `A` -- either an explicitly defined implicit or a derived codec. */
+  def apply[A](implicit ic: ImplicitCodec[A]): ImplicitCodec[A] = ic
+
+  implicit def fromImplicit[A](implicit c: Codec[A]): ImplicitCodec[A] = new ImplicitCodec[A] {
+    val codec = c
+  }
+}

--- a/src/main/scala/scodec/codecs/implicits.scala
+++ b/src/main/scala/scodec/codecs/implicits.scala
@@ -22,9 +22,9 @@ trait ImplicitValues {
 
 /** Provides implicit codecs for collection types. */
 trait ImplicitCollections {
-  implicit def implicitListCodec[A](implicit ccount: Codec[Int], ca: Codec[A]): Codec[List[A]] = listOfN(ccount, ca)
-  implicit def implicitVectorCodec[A](implicit ccount: Codec[Int], ca: Codec[A]): Codec[Vector[A]] = vectorOfN(ccount, ca)
-  implicit def implicitOptionCodec[A](implicit cguard: Codec[Boolean], ca: Codec[A]): Codec[Option[A]] = optional(cguard, ca)
+  implicit def implicitListCodec[A](implicit ccount: ImplicitCodec[Int], ca: ImplicitCodec[A]): Codec[List[A]] = listOfN(ccount, ca)
+  implicit def implicitVectorCodec[A](implicit ccount: ImplicitCodec[Int], ca: ImplicitCodec[A]): Codec[Vector[A]] = vectorOfN(ccount, ca)
+  implicit def implicitOptionCodec[A](implicit cguard: ImplicitCodec[Boolean], ca: ImplicitCodec[A]): Codec[Option[A]] = optional(cguard, ca)
 }
 
 /** Provides implicit codecs for common types. */

--- a/src/test/scala/scodec/CodecTest.scala
+++ b/src/test/scala/scodec/CodecTest.scala
@@ -139,41 +139,4 @@ class CodecTest extends CodecSuite {
       char8.encode('a') shouldBe -\/(Err("encoding not supported"))
     }
   }
-
-  "automatic codec generation" should {
-    "support automatic generation of HList codecs" in {
-      implicit val (i, s) = (uint8, variableSizeBytes(uint16, utf8))
-      Codec.product[Int :: Int :: String :: HNil].encodeValid(1 :: 2 :: "Hello" :: HNil) shouldBe hex"0102000548656c6c6f".bits
-    }
-    "support automatic generation of case class codecs" in {
-      implicit val (i, s) = (uint8, variableSizeBytes(uint16, utf8))
-      Codec.product[Foo].encodeValid(Foo(1, 2, "Hello")) shouldBe hex"0102000548656c6c6f".bits
-    }
-    "include field names in case class codecs" in {
-      implicit val (i, s) = (uint8, variableSizeBytes(uint16, utf8))
-      Codec.product[Foo].encode(Foo(1, 256, "Hello")) shouldBe left(Err("256 is greater than maximum value 255 for 8-bit unsigned integer").pushContext("y"))
-    }
-    "support automatic generation of coproduct codec builders" in {
-      implicit val (u, s) = (constant(1), variableSizeBytes(uint16, utf8))
-      type C = Unit :+: String :+: CNil
-      val codec = Codec.coproduct[C].choice
-      codec.encodeValid(Coproduct[C]("Hello")) shouldBe hex"000548656c6c6f".bits
-      codec.encodeValid(Coproduct[C](())) shouldBe hex"01".bits
-    }
-    "support automatic generation of coproduct codec builders from union types" in {
-      implicit val (i, s) = (uint8, variableSizeBytes(uint16, utf8))
-      val uSchema = RecordType.like('i ->> 24 :: 's ->> "foo" :: HNil)
-      type U = uSchema.Union
-      val codec = Codec.coproduct[U].discriminatedByIndex(uint8)
-      codec.encodeValid(Coproduct[U]('s ->> "Hello")) shouldBe hex"01000548656c6c6f".bits
-      codec.encode(Coproduct[U]('i ->> 256)) shouldBe left(Err("256 is greater than maximum value 255 for 8-bit unsigned integer").pushContext("i"))
-    }
-    "support automatic generation of coproduct codec builders from sealed trait and subclasses" in {
-      implicit val (i, s) = (uint8, variableSizeBytes(uint16, utf8))
-      implicit val (f, b) = (Codec.product[Foo], Codec.product[Bar])
-      val codec: Codec[Parent] = Codec.coproduct[Parent].discriminatedByIndex(uint8)
-      codec.encodeValid(Foo(1, 2, "Hello")) shouldBe hex"010102000548656c6c6f".bits
-      codec.encodeValid(Bar(1)) shouldBe hex"0001".bits
-    }
-  }
 }

--- a/src/test/scala/scodec/DerivedCodecTest.scala
+++ b/src/test/scala/scodec/DerivedCodecTest.scala
@@ -1,0 +1,54 @@
+package scodec
+
+import scalaz.{\/, -\/, \/-}
+import \/.{ right, left }
+
+import scodec.bits._
+import scodec.codecs._
+import shapeless._
+import shapeless.record._
+import shapeless.union._
+import shapeless.syntax.singleton._
+
+class DerivedCodecTest extends CodecSuite {
+
+  sealed trait Parent
+  case class Foo(x: Int, y: Int, s: String) extends Parent
+  case class Bar(x: Int) extends Parent
+
+  "automatic codec generation" should {
+    "support automatic generation of HList codecs" in {
+      implicit val (i, s) = (uint8, variableSizeBytes(uint16, utf8))
+      Codec.derive[Int :: Int :: String :: HNil].encodeValid(1 :: 2 :: "Hello" :: HNil) shouldBe hex"0102000548656c6c6f".bits
+    }
+    "support automatic generation of case class codecs" in {
+      implicit val (i, s) = (uint8, variableSizeBytes(uint16, utf8))
+      Codec.derive[Foo].encodeValid(Foo(1, 2, "Hello")) shouldBe hex"0102000548656c6c6f".bits
+    }
+    "include field names in case class codecs" in {
+      implicit val (i, s) = (uint8, variableSizeBytes(uint16, utf8))
+      Codec.derive[Foo].encode(Foo(1, 256, "Hello")) shouldBe left(Err("256 is greater than maximum value 255 for 8-bit unsigned integer").pushContext("y"))
+    }
+    "support automatic generation of coproduct codec builders" in {
+      implicit val (u, s) = (constant(1), variableSizeBytes(uint16, utf8))
+      type C = Unit :+: String :+: CNil
+      val codec = Codec.coproduct[C].choice
+      codec.encodeValid(Coproduct[C]("Hello")) shouldBe hex"000548656c6c6f".bits
+      codec.encodeValid(Coproduct[C](())) shouldBe hex"01".bits
+    }
+    "support automatic generation of coproduct codec builders from union types" in {
+      implicit val (i, s) = (uint8, variableSizeBytes(uint16, utf8))
+      val uSchema = RecordType.like('i ->> 24 :: 's ->> "foo" :: HNil)
+      type U = uSchema.Union
+      val codec = Codec.coproduct[U].discriminatedByIndex(uint8)
+      codec.encodeValid(Coproduct[U]('s ->> "Hello")) shouldBe hex"01000548656c6c6f".bits
+      codec.encode(Coproduct[U]('i ->> 256)) shouldBe left(Err("256 is greater than maximum value 255 for 8-bit unsigned integer").pushContext("i"))
+    }
+    "support automatic generation of coproduct codec builders from sealed trait and subclasses" in {
+      implicit val (i, s) = (uint8, variableSizeBytes(uint16, utf8))
+      val codec: Codec[Parent] = Codec.coproduct[Parent].discriminatedByIndex(uint8)
+      codec.encodeValid(Foo(1, 2, "Hello")) shouldBe hex"010102000548656c6c6f".bits
+      codec.encodeValid(Bar(1)) shouldBe hex"0001".bits
+    }
+  }
+}

--- a/src/test/scala/scodec/examples/DerivedCodecExamples.scala
+++ b/src/test/scala/scodec/examples/DerivedCodecExamples.scala
@@ -25,7 +25,28 @@ class DerivedCodecsExample extends CodecSuite {
     implicit val discriminator: Discriminator[Sprocket, Wocket, Int] = Discriminator(2)
   }
 
+  case class Wootle(count: Int, data: BitVector) extends Sprocket
+  object Wootle {
+    implicit val discriminator: Discriminator[Sprocket, Wootle, Int] = Discriminator(3)
+    implicit val codec: Codec[Wootle] = (uint8 :: bits).as[Wootle]
+  }
+
   case class Geiling(name: String, sprockets: Vector[Sprocket])
+
+  sealed trait Color
+  object Color {
+    case object Red extends Color
+    case object Yellow extends Color
+    case object Green extends Color
+
+    implicit val d: Discriminated[Color, Int] = Discriminated(uint8)
+
+    implicit val codec: Codec[Color] = mappedEnum(uint8,
+      Red -> 0,
+      Yellow -> 1,
+      Green -> 2
+    )
+  }
 
   "derived codec examples" should {
 
@@ -60,6 +81,11 @@ class DerivedCodecsExample extends CodecSuite {
       Codec[Sprocket].encodeValid(Wocket(3, true)) shouldBe hex"020301".bits
     }
 
+    "demonstrate subtype overrides in companion" in {
+      // Alternatively, the overriden codec can be defined in the companion of the subtype.
+      Codec[Sprocket].encodeValid(Wootle(4, hex"deadbeef".bits)) shouldBe hex"0304deadbeef".bits
+    }
+
     "demonstrate nested derivations" in {
       // Derived codecs can be based on other derived codecs.
       //
@@ -71,6 +97,10 @@ class DerivedCodecsExample extends CodecSuite {
       val encoded = Codec[Geiling].encodeValid(ceil)
       encoded shouldBe hex"00000004 4365696c 00000002 010000000100000002 0200000003ff".bits
       Codec[Geiling].decodeValidValue(encoded) shouldBe ceil
+    }
+
+    "demonstrate that derivation support does not interfere with manually authored implicit codecs in companions" in {
+      Codec[Color].encodeValid(Color.Green) shouldBe hex"02".bits
     }
   }
 }

--- a/src/test/scala/scodec/examples/ProductsExample.scala
+++ b/src/test/scala/scodec/examples/ProductsExample.scala
@@ -18,7 +18,7 @@ class ProductsExample extends CodecSuite {
       // as long as there's an implicit codec available for each
       // component type.
       implicit val i = uint8
-      val codec = Codec.product[Woozle]
+      val codec = Codec.derive[Woozle]
 
       codec.encodeValid(Woozle(1, 2)) shouldBe hex"0102".bits
 
@@ -31,7 +31,7 @@ class ProductsExample extends CodecSuite {
       // Auto generated case class codecs label each component codec
       // with the field name from the case class.
       implicit val i = uint8
-      val codec = Codec.product[Woozle]
+      val codec = Codec.derive[Woozle]
 
       codec.encode(Woozle(1, 256)) shouldBe \/.left(Err("256 is greater than maximum value 255 for 8-bit unsigned integer").pushContext("strength"))
     }
@@ -39,7 +39,7 @@ class ProductsExample extends CodecSuite {
     "demonstrate hlist generation" in {
       // Codec.product supports direct `HList` types as well.
       implicit val (i, b) = (uint8, bool)
-      val codec = Codec.product[Int :: Int :: Boolean :: HNil]
+      val codec = Codec.derive[Int :: Int :: Boolean :: HNil]
 
       codec.encodeValid(1 :: 2 :: true :: HNil) shouldBe hex"0102ff".bits.dropRight(7)
     }


### PR DESCRIPTION
Prefer explicitly defined implicit codecs over derived codecs and
provide a mechanism that allows selection of either.

This PR introduces `scodec.ImplicitCodec`, which gives precedent to
implicit `Codec` instances over derived codecs. Additionally,
`scodec.DerivedCodec` has been extracted from `Codec.Derive`, allowing
derived codecs to be explicitly requested.

When defining a generic combinator that depends on an implicitly
available codec, a decision must be made between requiring an implicit
`Codec`, `DerivedCodec`, and `ImplicitCodec`. The last should generally
be used.

There are some other minor changes including:
- code organization - derivation methods moved to `DerivedCodec`
- code organization - Codec.CoproductAuto moved to
  `codecs.CoproductBuilderAuto`
- deprecation of `Codec.product` as it is now synonymous with
  `Codec.derive`
- change to implicit parameter order in `DerivedCodec.coproduct` so that
  compiler bails out early if there's no `Discriminated[A, D]` in scope
