### PR TITLE
Adds Err for case when matching discriminator in encoding is not found.

### DIFF
--- a/src/main/scala/scodec/Err.scala
+++ b/src/main/scala/scodec/Err.scala
@@ -44,6 +44,12 @@ object Err {
     def pushContext(ctx: String) = copy(context = ctx :: context)
   }
 
+  case class MatchingDiscriminatorNotFound[A](a: A, context: List[String]) extends Err {
+    def this(a: A) = this(a, Nil)
+    def message = s"could not find matching case for $a"
+    def pushContext(ctx: String) = copy(context = ctx :: context)
+  }
+
   def apply(message: String): Err = new General(message)
   def insufficientBits(needed: Long, have: Long): Err = new InsufficientBits(needed, have)
 }

--- a/src/main/scala/scodec/codecs/DiscriminatorCodec.scala
+++ b/src/main/scala/scodec/codecs/DiscriminatorCodec.scala
@@ -334,7 +334,7 @@ final class DiscriminatorCodec[A, B] private[codecs] (by: Codec[B], cases: Vecto
           .flatMap { bits => k.prism.repCodec.encode(r).map(bits ++ _) }
       }.map(List(_)).getOrElse(List())
     }.toStream.headOption match {
-      case None => left(Err(s"could not find matching case for $a"))
+      case None => left(new Err.MatchingDiscriminatorNotFound(a))
       case Some(r) => r
     }
 

--- a/src/test/scala/scodec/CodecSuite.scala
+++ b/src/test/scala/scodec/CodecSuite.scala
@@ -3,7 +3,7 @@ package scodec
 import scala.collection.GenTraversable
 import scala.concurrent.duration._
 
-import scalaz.\/-
+import scalaz.{-\/, \/-}
 import scalaz.syntax.either._
 
 import org.scalacheck.Gen
@@ -28,6 +28,13 @@ abstract class CodecSuite extends WordSpec with Matchers with GeneratorDrivenPro
 
   protected def roundtripAll[A](codec: Codec[A], as: GenTraversable[A]) {
     as foreach { a => roundtrip(codec, a) }
+  }
+
+  protected def encodeError[A](codec: Codec[A], a: A, err: Err) {
+    val encoded = codec.encode(a)
+    encoded should be ('left)
+    val -\/(error) = encoded
+    error shouldBe err
   }
 
   protected def shouldDecodeFullyTo[A](codec: Codec[A], buf: BitVector, expected: A): Unit = {

--- a/src/test/scala/scodec/codecs/DiscriminatorCodecTest.scala
+++ b/src/test/scala/scodec/codecs/DiscriminatorCodecTest.scala
@@ -132,5 +132,17 @@ class DiscriminatorCodecTest extends CodecSuite {
       roundtrip(treeCodec, Leaf(42))
       roundtrip(treeCodec, Node(Leaf(42), Node(Leaf(1), Leaf(2))))
     }
+
+    "error when matching discriminator for encoding is not found" in {
+      val codec =
+        discriminated[AnyVal].by(uint8)
+        .typecase(0, bool)
+
+      roundtrip(codec, true)
+      roundtrip(codec, false)
+      encodeError(codec, 1, new Err.MatchingDiscriminatorNotFound(1))
+      encodeError(codec, Int.MaxValue, new Err.MatchingDiscriminatorNotFound(Int.MaxValue))
+    }
+
   }
 }


### PR DESCRIPTION
Gives this specific error a type so I don't have to check the contents of the message string to be sure it's this type.
