### PR TITLE
Add little endian versions of string32, ascii32 and utf8_32.

### DIFF
--- a/src/main/scala/scodec/codecs/package.scala
+++ b/src/main/scala/scodec/codecs/package.scala
@@ -468,6 +468,16 @@ package object codecs {
     variableSizeBytes(int32, string(charset)).withToString(s"string32(${charset.displayName})")
 
   /**
+   * String codec that uses the implicit `Charset` and prefixes the encoded string by the byte size
+   * in a 32-bit 2s complement little endian field.
+   *
+   * @param charset charset to use to convert strings to/from binary
+   * @group values
+   */
+  def string32L(implicit charset: Charset): Codec[String] =
+    variableSizeBytes(int32L, string(charset)).withToString(s"string32(${charset.displayName})")
+
+  /**
    * String codec that uses the `US-ASCII` charset and prefixes the encoded string by the byte size
    * in a 32-bit 2s complement big endian field.
    * @group values
@@ -475,11 +485,25 @@ package object codecs {
   val ascii32 = string32(Charset.forName("US-ASCII"))
 
   /**
+   * String codec that uses the `US-ASCII` charset and prefixes the encoded string by the byte size
+   * in a 32-bit 2s complement little endian field.
+   * @group values
+   */
+  val ascii32L = string32L(Charset.forName("US-ASCII"))
+
+  /**
    * String codec that uses the `UTF-8` charset and prefixes the encoded string by the byte size
    * in a 32-bit 2s complement big endian field.
    * @group values
    */
   val utf8_32 = string32(Charset.forName("UTF-8"))
+
+  /**
+   * String codec that uses the `UTF-8` charset and prefixes the encoded string by the byte size
+   * in a 32-bit 2s complement little endian field.
+   * @group values
+   */
+  val utf8_32L = string32L(Charset.forName("UTF-8"))
 
   /**
    * Encodes/decodes `UUID`s as 2 64-bit big-endian longs, first the high 64-bits then the low 64-bits.

--- a/src/test/scala/scodec/codecs/StringCodecTest.scala
+++ b/src/test/scala/scodec/codecs/StringCodecTest.scala
@@ -11,9 +11,33 @@ class StringCodecTest extends CodecSuite {
     }
   }
 
+  "ascii32 codec" should {
+    "roundtrip" in {
+      roundtripAll(ascii32, Seq("test", "", "with\ttabs"))
+    }
+  }
+
+  "ascii32L codec" should {
+    "roundtrip" in {
+      roundtripAll(ascii32L, Seq("test", "", "with\ttabs"))
+    }
+  }
+
   "utf8 codec" should {
     "roundtrip" in {
       roundtripAll(utf8, Seq("test", "", "with\ttabs", "withλ"))
+    }
+  }
+
+  "utf8_32 codec" should {
+    "roundtrip" in {
+      roundtripAll(utf8_32, Seq("test", "", "with\ttabs", "withλ"))
+    }
+  }
+
+  "utf8_32L codec" should {
+    "roundtrip" in {
+      roundtripAll(utf8_32L, Seq("test", "", "with\ttabs", "withλ"))
     }
   }
 


### PR DESCRIPTION
I came across the need for little endian versions of the string32 codecs. I added three new codecs: string32L, ascii32L and utf8_32L. The only difference is that the string length field is encoded little endian rather than big endian.