### PR TITLE
Add varint and varlong codecs

### DIFF
--- a/shared/src/main/scala/scodec/codecs/VarIntCodec.scala
+++ b/shared/src/main/scala/scodec/codecs/VarIntCodec.scala
@@ -1,0 +1,27 @@
+package scodec
+package codecs
+
+import scodec.bits.{BitVector, ByteOrdering}
+
+private[codecs] final class VarIntCodec(ordering: ByteOrdering) extends Codec[Int] {
+  private[this] val long = new VarLongCodec(ordering).xmap(_.toInt, VarIntCodec.toPositiveLong)
+
+  override def sizeBound =
+    SizeBound.bounded(1L, 5L)
+
+  override def encode(i: Int) =
+    long.encode(i)
+
+  override def decode(buffer: BitVector) =
+    long.decode(buffer)
+
+  override def toString = "variable-length integer"
+}
+object VarIntCodec {
+  private val NegativeIntSignBit = Int.MaxValue.toLong + 1L
+
+  // toLong left-pads with `1` if the int is negative which cannot be encoded by
+  // the VarLongCodec. This pads negative ints with `0` instead.
+  private val toPositiveLong = (i: Int) =>
+    if (i >= 0) i.toLong else (i & Int.MaxValue) | NegativeIntSignBit
+}

--- a/shared/src/main/scala/scodec/codecs/VarLongCodec.scala
+++ b/shared/src/main/scala/scodec/codecs/VarLongCodec.scala
@@ -1,0 +1,103 @@
+package scodec
+package codecs
+
+import java.nio.{ByteBuffer, ByteOrder}
+
+import scodec.bits.ByteOrdering.BigEndian
+import scodec.bits.{BitVector, ByteOrdering}
+
+import scala.annotation.tailrec
+
+private[codecs] final class VarLongCodec(ordering: ByteOrdering) extends Codec[Long] {
+  import VarLongCodec._
+
+  override def sizeBound = SizeBound.bounded(1L, 9L)
+
+  override def encode(i: Long) = {
+    require(i >= 0, "VarLong cannot encode negative longs")
+    val buffer = ByteBuffer.allocate(9).order(ByteOrder.BIG_ENDIAN)
+    val encoder = if (ordering == BigEndian) BEEncoder else LEEncoder
+    val written = encoder(i, buffer)
+    buffer.flip()
+    val relevantBits = BitVector.view(buffer).take(written.toLong)
+    val bits = if (ordering == BigEndian) relevantBits else relevantBits.reverseByteOrder
+    Attempt.successful(bits)
+  }
+
+  override def decode(buffer: BitVector) = {
+    val decoder = if (ordering == BigEndian) BEDecoder else LEDecoder
+    decoder(buffer)
+  }
+
+  override def toString = "variable-length integer"
+
+  private val BEEncoder = (value: Long, buffer: ByteBuffer) =>
+    runEncodingBE(value, buffer, 8)
+
+  private val LEEncoder = (value: Long, buffer: ByteBuffer) =>
+    runEncodingLE(value, buffer, 8, 0)
+
+  @tailrec
+  private def runEncodingBE(value: Long, buffer: ByteBuffer, size: Int): Int = {
+    if ((value & MoreBytesMask) != 0) {
+      buffer.put((value & RelevantDataBits | MostSignificantBit).toByte)
+      runEncodingBE(value >>> BitsPerByte, buffer, size + 8)
+    } else {
+      buffer.put(value.toByte)
+      size
+    }
+  }
+
+  @tailrec
+  private def runEncodingLE(value: Long, buffer: ByteBuffer, size: Int, msbMask: Int): Int = {
+    if ((value & MoreBytesMask) != 0) {
+      buffer.put((value & RelevantDataBits | msbMask).toByte)
+      runEncodingLE(value >>> BitsPerByte, buffer, size + 8, MostSignificantBit)
+    } else {
+      buffer.put((value | msbMask).toByte)
+      size
+    }
+  }
+
+  private val BEDecoder = (buffer: BitVector) =>
+    runDecodingBE(buffer, MostSignificantBit.toByte, 0L, 0)
+
+  private val LEDecoder = (buffer: BitVector) =>
+    runDecodingLE(buffer, MostSignificantBit.toByte, 0L)
+
+  @tailrec
+  private def runDecodingBE(buffer: BitVector, byte: Byte, value: Long, shift: Int): Attempt[DecodeResult[Long]] = {
+    if ((byte & MostSignificantBit) != 0) {
+      if (buffer.sizeLessThan(8L)) {
+        Attempt.failure(Err.InsufficientBits(8L, buffer.size, Nil))
+      } else {
+        val nextByte = buffer.take(8L).toByte(false)
+        val nextValue = value | (nextByte & RelevantDataBits) << shift
+        runDecodingBE(buffer.drop(8L), nextByte, nextValue, shift + BitsPerByte)
+      }
+    } else {
+      Attempt.successful(DecodeResult(value, buffer))
+    }
+  }
+
+  @tailrec
+  private def runDecodingLE(buffer: BitVector, byte: Byte, value: Long): Attempt[DecodeResult[Long]] = {
+    if ((byte & MostSignificantBit) != 0) {
+      if (buffer.sizeLessThan(8L)) {
+        Attempt.failure(Err.InsufficientBits(8L, buffer.size, Nil))
+      } else {
+        val nextByte = buffer.take(8L).toByte(false)
+        val nextValue = (value << BitsPerByte) | (nextByte & RelevantDataBits)
+        runDecodingLE(buffer.drop(8L), nextByte, nextValue)
+      }
+    } else {
+      Attempt.successful(DecodeResult(value, buffer))
+    }
+  }
+}
+object VarLongCodec {
+  private val RelevantDataBits   = 0x7FL
+  private val MoreBytesMask      = ~RelevantDataBits.toInt
+  private val MostSignificantBit = 0x80
+  private val BitsPerByte        = 7
+}

--- a/shared/src/main/scala/scodec/codecs/package.scala
+++ b/shared/src/main/scala/scodec/codecs/package.scala
@@ -289,6 +289,40 @@ package object codecs {
   val uint32L: Codec[Long] = new LongCodec(32, false, ByteOrdering.LittleEndian)
 
   /**
+   * Codec for variable-length big-endian integers.
+   * Encoding requires between 1 and 5 bytes, depending on the value.
+   * Smaller ints require less bytes. Negative values are always encoded with 5 bytes.
+   * @group numbers
+   */
+  val vint: Codec[Int] = new VarIntCodec(ByteOrdering.BigEndian)
+
+  /**
+   * Codec for variable-length little-endian integers.
+   * Encoding requires between 1 and 5 bytes, depending on the value.
+   * Smaller ints require less bytes. Negative values are always encoded with 5 bytes.
+   * @group numbers
+   */
+  val vintL: Codec[Int] = new VarIntCodec(ByteOrdering.LittleEndian)
+
+  /**
+   * Codec for variable-length big-endian longs.
+   * Encoding requires between 1 and 9 bytes, depending on the value.
+   * Smaller longs require less bytes.
+   * Negative values are not supported.
+   * @group numbers
+   */
+  val vlong: Codec[Long] = new VarLongCodec(ByteOrdering.BigEndian)
+
+  /**
+   * Codec for variable-length little-endian longs.
+   * Encoding requires between 1 and 9 bytes, depending on the value.
+   * Smaller longs require less bytes.
+   * Negative values are not supported.
+   * @group numbers
+   */
+  val vlongL: Codec[Long] = new VarLongCodec(ByteOrdering.LittleEndian)
+
+  /**
    * Codec for n-bit 2s complement bytes.
    * @param size number of bits (must be 0 < size <= 8)
    * @group numbers

--- a/shared/src/test/scala/scodec/codecs/VarIntCodecTest.scala
+++ b/shared/src/test/scala/scodec/codecs/VarIntCodecTest.scala
@@ -1,0 +1,34 @@
+package scodec
+package codecs
+
+import org.scalacheck.Gen
+
+class VarIntCodecTest extends CodecSuite {
+  def check(low: Int, high: Int, size: Int)(codec: Codec[Int]): Unit = {
+    forAll(Gen.choose(low, high)) { n =>
+      codec.encode(n).map(_.bytes.size) shouldBe Attempt.successful(size)
+    }
+  }
+
+  "the vint codec" should {
+    "roundtrip" in forAll(Gen.choose(Int.MinValue, Int.MaxValue))(roundtrip(vint, _))
+
+    "use 1 byte for ints <= 7 bits" in check(0, 127, 1)(vint)
+    "use 2 bytes for ints <= 14 bits" in check(128, 16383, 2)(vint)
+    "use 3 bytes for ints <= 21 bits" in check(16384, 2097151, 3)(vint)
+    "use 4 bytes for ints <= 28 bits" in check(2097152, 268435455, 4)(vint)
+    "use 5 bytes for ints <= 32 bits" in check(268435456, Int.MaxValue, 5)(vint)
+    "use 5 bytes for negative ints" in check(Int.MinValue, -1, 5)(vint)
+  }
+
+  "the vintL codec" should {
+    "roundtrip" in forAll(Gen.choose(0, Int.MaxValue))(roundtrip(vintL, _))
+
+    "use 1 byte for ints <= 7 bits" in check(0, 127, 1)(vintL)
+    "use 2 bytes for ints <= 14 bits" in check(128, 16383, 2)(vintL)
+    "use 3 bytes for ints <= 21 bits" in check(16384, 2097151, 3)(vintL)
+    "use 4 bytes for ints <= 28 bits" in check(2097152, 268435455, 4)(vintL)
+    "use 5 bytes for ints <= 32 bits" in check(268435456, Int.MaxValue, 5)(vintL)
+    "use 5 bytes for negative ints" in check(Int.MinValue, -1, 5)(vintL)
+  }
+}

--- a/shared/src/test/scala/scodec/codecs/VarLongCodecTest.scala
+++ b/shared/src/test/scala/scodec/codecs/VarLongCodecTest.scala
@@ -1,0 +1,40 @@
+package scodec
+package codecs
+
+import org.scalacheck.Gen
+
+class VarLongCodecTest extends CodecSuite {
+  def check(low: Long, high: Long, size: Int)(codec: Codec[Long]): Unit = {
+    forAll(Gen.choose(low, high)) { n =>
+      codec.encode(n).map(_.bytes.size) shouldBe Attempt.successful(size)
+    }
+  }
+
+  "the vlong codec" should {
+    "roundtrip" in forAll(Gen.choose(0L, Long.MaxValue))(roundtrip(vlong, _))
+
+    "use 1 byte for longs <= 7 bits" in check(0L, 127L, 1)(vlong)
+    "use 2 bytes for longs <= 14 bits" in check(128L, 16383L, 2)(vlong)
+    "use 3 bytes for longs <= 21 bits" in check(16384L, 2097151L, 3)(vlong)
+    "use 4 bytes for longs <= 28 bits" in check(2097152L, 268435455L, 4)(vlong)
+    "use 5 bytes for longs <= 35 bits" in check(268435456L, 34359738367L, 5)(vlong)
+    "use 6 bytes for longs <= 42 bits" in check(34359738368L, 4398046511103L, 6)(vlong)
+    "use 7 bytes for longs <= 49 bits" in check(4398046511104L, 562949953421311L, 7)(vlong)
+    "use 8 bytes for longs <= 56 bits" in check(562949953421312L, 72057594037927935L, 8)(vlong)
+    "use 9 bytes for longs <= 63 bits" in check(72057594037927936L, Long.MaxValue, 9)(vlong)
+  }
+
+  "the vlongL codec" should {
+    "roundtrip" in forAll(Gen.choose(0L, Long.MaxValue))(roundtrip(vlongL, _))
+
+    "use 1 byte for longs <= 7 bits" in check(0L, 127L, 1)(vlongL)
+    "use 2 bytes for longs <= 14 bits" in check(128L, 16383L, 2)(vlongL)
+    "use 3 bytes for longs <= 21 bits" in check(16384L, 2097151L, 3)(vlongL)
+    "use 4 bytes for longs <= 28 bits" in check(2097152L, 268435455L, 4)(vlongL)
+    "use 5 bytes for longs <= 35 bits" in check(268435456L, 34359738367L, 5)(vlongL)
+    "use 6 bytes for longs <= 42 bits" in check(34359738368L, 4398046511103L, 6)(vlongL)
+    "use 7 bytes for longs <= 49 bits" in check(4398046511104L, 562949953421311L, 7)(vlongL)
+    "use 8 bytes for longs <= 56 bits" in check(562949953421312L, 72057594037927935L, 8)(vlongL)
+    "use 9 bytes for longs <= 63 bits" in check(72057594037927936L, Long.MaxValue, 9)(vlongL)
+  }
+}


### PR DESCRIPTION
A first sketch on a [variable length](https://en.wikipedia.org/wiki/Variable-length_quantity) implementation for ints and longs, useful as a general purpose int-packing.

The implementation has some duplicated code, but I haven't figured out a good way to abstract over this. The alternative would have been a tailrec method with some 6 or 7 parameters, which is not really better, imho.
Also, `vint` could probably be just the `vlong.xmap(...)` bit except for the `sizeBound`. Is there maybe a way to adjust the size bound, similar to `withContext` and `withToString`?

A downside of these encodings is, they work poorly with negative values. Negative ints will always have a penalty and be encoded in 5 bytes; negative longs aren't even supported in the first place.
There is a variant of this called zigzag-encoding, which works around this limitation by jumping between negative and positive values and makes the required size dependent on the absolute value.
I could later add a zigzag encoding (zint/zlong) to address this, I just wanted to have these out of the way.
