### PR TITLE
Minor optimizations to UUID codec

### DIFF
--- a/benchmark/src/main/scala/UuidBenchmark.scala
+++ b/benchmark/src/main/scala/UuidBenchmark.scala
@@ -1,0 +1,24 @@
+package scodec
+
+import org.openjdk.jmh.annotations._
+import java.util.concurrent.TimeUnit
+import java.util.UUID
+import scodec.bits.BitVector
+
+@BenchmarkMode(Array(Mode.AverageTime))
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+class UuidBenchmark {
+  val uuid = UUID.fromString("b0739ffd-d1f9-47b8-aa2e-b2be69733def")
+  val codec = codecs.uuid
+
+  val encoded: BitVector = encode.toOption.get // YOLO
+
+  assert(decode.isSuccessful)
+
+  @Benchmark def encode: Attempt[BitVector] =
+    codec.encode(uuid)
+
+  @Benchmark def decode: Attempt[DecodeResult[UUID]] =
+    codec.decode(encoded)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -39,3 +39,7 @@ lazy val core = crossProject.in(file(".")).
 
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js
+
+lazy val benchmark: Project = project.in(file("benchmark")).dependsOn(coreJVM).enablePlugins(JmhPlugin).
+  settings(commonSettings: _*).
+  settings(publishArtifact := false)

--- a/shared/src/main/scala/scodec/codecs/UuidCodec.scala
+++ b/shared/src/main/scala/scodec/codecs/UuidCodec.scala
@@ -6,15 +6,15 @@ import scodec.bits.BitVector
 
 private[codecs] object UuidCodec extends Codec[UUID] {
 
-  val codec = int64 ~ int64
+  private val mkUUID: (Long, Long) => UUID = new UUID(_, _)
 
-  override def sizeBound = codec.sizeBound
+  override val sizeBound = int64.sizeBound * 2L
 
   override def encode(u: UUID) =
-    codec.encode((u.getMostSignificantBits, u.getLeastSignificantBits))
+    Codec.encodeBoth(int64, int64)(u.getMostSignificantBits, u.getLeastSignificantBits)
 
   override def decode(bits: BitVector) =
-    codec.decode(bits) map { _ map { case (m, l) => new UUID(m, l) } }
+    Codec.decodeBothCombine(int64, int64)(bits)(mkUUID)
 
   override def toString = "uuid"
 }


### PR DESCRIPTION
This provides a minor optimization to the UUID codec by avoiding going through an intermediate tuple.

I'm not sure such a minor change is justified, but this also adds a `benchmark` module that I think would be nice to have going forward.

Here are the results of the benchmark on my machine before and after the
optimizations:

Before change:
```
[info] Benchmark             Mode  Cnt  Score    Error  Units
[info] UuidBenchmark.decode  avgt  200  0.221 ±  0.008  us/op
[info] UuidBenchmark.encode  avgt  200  0.097 ±  0.001  us/op
```

After change:
```
[info] Benchmark             Mode  Cnt  Score    Error  Units
[info] UuidBenchmark.decode  avgt  200  0.196 ±  0.003  us/op
[info] UuidBenchmark.encode  avgt  200  0.088 ±  0.001  us/op
```