### PR TITLE
Drop obsolete .build call in discriminated doc

### DIFF
--- a/shared/src/main/scala/scodec/codecs/package.scala
+++ b/shared/src/main/scala/scodec/codecs/package.scala
@@ -1637,7 +1637,6 @@ package object codecs {
      discriminated[Either[A,B]].by(uint8)
      .| (0) { case Left(l) => l } (Left.apply) (codecA)
      .| (1) { case Right(r) => r } (Right.apply) (codecB)
-     .build
    }}}
 
    * This encodes an `Either[A,B]` by checking the given patterns


### PR DESCRIPTION
It looks like the `build` method no longer exists.