### PR TITLE
Make ConditionalCodec CallByName

### DIFF
--- a/shared/src/main/scala/scodec/codecs/ConditionalCodec.scala
+++ b/shared/src/main/scala/scodec/codecs/ConditionalCodec.scala
@@ -3,7 +3,7 @@ package codecs
 
 import scodec.bits.BitVector
 
-private[codecs] final class ConditionalCodec[A](included: Boolean, codec: Codec[A]) extends Codec[Option[A]] {
+private[codecs] final class ConditionalCodec[A](included: Boolean, codec: => Codec[A]) extends Codec[Option[A]] {
 
   override def sizeBound = if (included) codec.sizeBound else SizeBound.exact(0)
 

--- a/shared/src/main/scala/scodec/codecs/package.scala
+++ b/shared/src/main/scala/scodec/codecs/package.scala
@@ -1023,7 +1023,7 @@ package object codecs {
    * @param codec codec to conditionally include
    * @group combinators
    */
-  def conditional[A](included: Boolean, codec: Codec[A]): Codec[Option[A]] = new ConditionalCodec(included, codec)
+  def conditional[A](included: Boolean, codec: => Codec[A]): Codec[Option[A]] = new ConditionalCodec(included, codec)
 
   /**
    * Codec of `Option[A]` that delegates to a `Codec[A]` when the `guard` codec decodes a true.

--- a/shared/src/test/scala/scodec/codecs/ConditionalCodecTest.scala
+++ b/shared/src/test/scala/scodec/codecs/ConditionalCodecTest.scala
@@ -1,0 +1,34 @@
+package scodec.codecs
+
+import scodec._
+
+class ConditionalCodecTest extends CodecSuite {
+
+  "conditional codec" should {
+
+    "not evaluate if condition is false" in {
+      var called = false
+
+      def retCodec(): Codec[String] = {
+        called = true
+        ascii
+      }
+
+      conditional(false, retCodec).encode(Some(""))
+      called should be (false)
+    }
+
+    "evaluate if condition is true" in {
+      var called = false
+
+      def retCodec(): Codec[String] = {
+        called = true
+        ascii
+      }
+
+      conditional(true, retCodec).encode(Some(""))
+      called should be (true)
+    }
+
+  }
+}


### PR DESCRIPTION
It probably should not evaluate `codec` parameter if `included` parameter is false.

I opened this PR since I'm having a problem with this exact situation:
The included parameter is false and the codec parameter is returned from a function.

It'll throw a `NoSuchElementException` when trying to evaluate codec, but since included
is obviously false in this situation, it is better to not evaluate codec at all.