### PR TITLE
Lazy Conditional Codec

### DIFF
--- a/shared/src/main/scala/scodec/codecs/ConditionalCodec.scala
+++ b/shared/src/main/scala/scodec/codecs/ConditionalCodec.scala
@@ -3,24 +3,26 @@ package codecs
 
 import scodec.bits.BitVector
 
-private[codecs] final class ConditionalCodec[A](included: Boolean, codec: Codec[A]) extends Codec[Option[A]] {
+private[codecs] final class ConditionalCodec[A](included: Boolean, codec: => Codec[A]) extends Codec[Option[A]] {
 
-  override def sizeBound = if (included) codec.sizeBound else SizeBound.exact(0)
+  private lazy val evaluatedCodec = codec
+
+  override def sizeBound = if (included) evaluatedCodec.sizeBound else SizeBound.exact(0)
 
   override def encode(a: Option[A]) = {
     a.filter { _ => included } match {
       case None => Attempt.successful(BitVector.empty)
-      case Some(a) => codec.encode(a)
+      case Some(a) => evaluatedCodec.encode(a)
     }
   }
 
   override def decode(buffer: BitVector) = {
     if (included)
-      codec.decode(buffer).map { _ map { result => Some(result) } }
+      evaluatedCodec.decode(buffer).map { _ map { result => Some(result) } }
     else
       Attempt.successful(DecodeResult(None, buffer))
   }
 
-  override def toString = s"conditional($included, $codec)"
+  override def toString = if(included) s"conditional(true, $evaluatedCodec)" else "conditional(false, ?)"
 
 }

--- a/shared/src/main/scala/scodec/codecs/package.scala
+++ b/shared/src/main/scala/scodec/codecs/package.scala
@@ -1023,7 +1023,7 @@ package object codecs {
    * @param codec codec to conditionally include
    * @group combinators
    */
-  def conditional[A](included: Boolean, codec: Codec[A]): Codec[Option[A]] = new ConditionalCodec(included, codec)
+  def conditional[A](included: Boolean, codec: => Codec[A]): Codec[Option[A]] = new ConditionalCodec(included, codec)
 
   /**
    * Codec of `Option[A]` that delegates to a `Codec[A]` when the `guard` codec decodes a true.

--- a/shared/src/test/scala/scodec/codecs/ConditionalCodecTest.scala
+++ b/shared/src/test/scala/scodec/codecs/ConditionalCodecTest.scala
@@ -1,0 +1,71 @@
+package scodec.codecs
+
+import scodec._
+import scodec.bits._
+
+class ConditionalCodecTest extends CodecSuite {
+
+  "conditional codec" should {
+
+    "not evaluate if condition is false when encoding" in {
+      var called = false
+
+      def retCodec(): Codec[String] = {
+        called = true
+        ascii
+      }
+
+      val result = conditional(false, retCodec).encode(Some("00"))
+
+      called should be (false)
+      result shouldBe a [Attempt.Successful[_]]
+      result.require shouldBe BitVector.empty
+    }
+
+    "evaluate if condition is true when encoding" in {
+      var called = false
+
+      def retCodec(): Codec[String] = {
+        called = true
+        ascii
+      }
+
+      val result = conditional(true, retCodec).encode(Some("00"))
+
+      called should be (true)
+      result shouldBe a [Attempt.Successful[_]]
+      result.require shouldBe hex"3030".bits
+    }
+
+    "not evaluate if condition is false when decoding" in {
+      var called = false
+
+      def retCodec(): Codec[String] = {
+        called = true
+        ascii
+      }
+
+      val result = conditional(false, retCodec).decode(hex"3030".bits)
+
+      called should be (false)
+      result shouldBe a [Attempt.Successful[_]]
+      result.require.value shouldBe None
+    }
+
+    "evaluate if condition is true when decoding" in {
+      var called = false
+
+      def retCodec(): Codec[String] = {
+        called = true
+        ascii
+      }
+
+      val result = conditional(true, retCodec).decode(hex"3030".bits)
+
+      called should be (true)
+      result shouldBe a [Attempt.Successful[_]]
+      result.require.value shouldBe Some("00")
+    }
+
+  }
+}


### PR DESCRIPTION
As stated on #82, the conditional codec should not evaluate the supplied codec if the condition is false. This PR changes the behavior of `ConditionalCodec` by making the `codec` parameter a 'call-by-name' and storing the evaluated result in a lazy val, thus evaluating the `codec` at most once.