### PR TITLE
Add left padded pbcd codec

### DIFF
--- a/shared/src/test/scala/scodec/codecs/PackedDecimalCodecTest.scala
+++ b/shared/src/test/scala/scodec/codecs/PackedDecimalCodecTest.scala
@@ -29,6 +29,7 @@ class PackedDecimalCodecTest extends CodecSuite {
 
     "decode correctly" in {
       lpbcd(6).decode(hex"010323".bits) should be (Attempt.successful(DecodeResult(10323L, BitVector.empty)))
+      lpbcd(5).decode(hex"010323".bits) should be (Attempt.successful(DecodeResult(10323L, BitVector.empty)))
     }
   }
 

--- a/shared/src/test/scala/scodec/codecs/PackedDecimalCodecTest.scala
+++ b/shared/src/test/scala/scodec/codecs/PackedDecimalCodecTest.scala
@@ -17,6 +17,19 @@ class PackedDecimalCodecTest extends CodecSuite {
     "decode correctly" in {
       pbcd(6).decode(hex"010323".bits) should be (Attempt.successful(DecodeResult(10323L, BitVector.empty)))
     }
+
+  }
+
+  "the lpbcd codec" should {
+    "encode correctly" in {
+      val encoded = lpbcd(3).encode(23L)
+      encoded should be (Attempt.successful(hex"023".bits))
+      encoded.map(_.bytes) should be (Attempt.successful(hex"0023"))
+    }
+
+    "decode correctly" in {
+      lpbcd(6).decode(hex"010323".bits) should be (Attempt.successful(DecodeResult(10323L, BitVector.empty)))
+    }
   }
 
 }


### PR DESCRIPTION
This way bcd-based encodings wih fewer nibbles than specified or with odd-nibble-sizes will be left-padded with 0, contrary to the pbcd codec