### PR TITLE
padded variable aligned codec

### DIFF
--- a/shared/src/main/scala/scodec/codecs/PaddedVarAlignedCodec.scala
+++ b/shared/src/main/scala/scodec/codecs/PaddedVarAlignedCodec.scala
@@ -1,0 +1,30 @@
+package scodec
+package codecs
+
+import scodec.{Codec, Err}
+import scodec.bits.BitVector
+
+class PaddedVarAlignedCodec[A](sizeCodec: Codec[Long], valueCodec: Codec[A], multipleForPadding: Long) extends Codec[A] {
+  
+  def calculatePadding(i: Long): Long = (multipleForPadding - (i % multipleForPadding)) % multipleForPadding
+
+  val decoder = for {
+    size <- sizeCodec
+    a <- fixedSizeBits(size, valueCodec)
+    _ <- ignore(calculatePadding(size))
+  } yield a
+
+  def sizeBound = sizeCodec.sizeBound.atLeast
+
+  override def encode(a: A) = for {
+    encA <- valueCodec.encode(a)
+    padsize = calculatePadding(encA.size)
+    encSize <- sizeCodec.encode(encA.size).mapErr { e => fail(a, e.messageWithContext) }
+  } yield encSize ++ encA ++ BitVector.fill(padsize)(false)
+
+  private def fail(a: A, msg: String): Err =
+    Err.General(s"failed to encode size of [$a]: $msg", List("size"))
+
+  override def decode(buffer: BitVector) =
+    decoder.decode(buffer)
+}

--- a/shared/src/main/scala/scodec/codecs/package.scala
+++ b/shared/src/main/scala/scodec/codecs/package.scala
@@ -823,11 +823,13 @@ package object codecs {
    * @group combinators
    */
    def paddedVarAlignedBits[A](sizeCodec: Codec[Long], valueCodec: Codec[A], multipleForPadding: Int) = new PaddedVarAlignedCodec(sizeCodec, valueCodec, multipleForPadding.toLong)
+  
   /**
    * Byte equivalent of [[paddedVarAligendBits]].
    * @param sizeCodec codec that determines the size
    * @param valueCodec coec for encoding the payload
    * @param multipleForPadding multiple of bytes to align the value to with padding
+   * @group combinators
    */
    def paddedVarAlignedBytes[A](sizeCodec: Codec[Int], valueCodec: Codec[A], multipleForPadding: Int) = new Codec[A] {
       val sizedWiden = widenIntToLong(sizeCodec) 

--- a/shared/src/main/scala/scodec/codecs/package.scala
+++ b/shared/src/main/scala/scodec/codecs/package.scala
@@ -811,6 +811,32 @@ package object codecs {
      def decode(b: BitVector) = fcodec.decode(b)
      override def toString = s"paddedFixedSizeBytes($size, $codec)"
    }
+  
+  /**
+   * Codec that pads on a multiplier.
+   * 
+   * Similar to ByteAligendCodec, but instead of only padding to 8 bits, pads to a variable size
+   *
+   * @param sizeCodec codec that determines the size
+   * @param valueCodec codec for encoding the payload
+   * @param multipleForPadding multiple to align the value to with padding
+   * @group combinators
+   */
+   def paddedVarAlignedBits[A](sizeCodec: Codec[Long], valueCodec: Codec[A], multipleForPadding: Int) = new PaddedVarAlignedCodec(sizeCodec, valueCodec, multipleForPadding.toLong)
+  /**
+   * Byte equivalent of [[paddedVarAligendBits]].
+   * @param sizeCodec codec that determines the size
+   * @param valueCodec coec for encoding the payload
+   * @param multipleForPadding multiple of bytes to align the value to with padding
+   */
+   def paddedVarAlignedBytes[A](sizeCodec: Codec[Int], valueCodec: Codec[A], multipleForPadding: Int) = new Codec[A] {
+      val sizedWiden = widenIntToLong(sizeCodec) 
+      private val codec = new PaddedVarAlignedCodec(sizedWiden.widen[Long](_ * 8, bitsToBytesDivisible), valueCodec, multipleForPadding.toLong * 8)
+      override def encode(a: A) = codec.encode(a)
+      override def decode(buffer: BitVector) = codec.decode(buffer)
+      override def sizeBound = codec.sizeBound
+      override def toString = "PaddedVarAlignedBytesCodec"
+   }
 
   /**
    * Codec that limits the number of bits the specified codec works with.

--- a/shared/src/test/scala/scodec/codecs/PaddedVarAlignedCodecTest.scala
+++ b/shared/src/test/scala/scodec/codecs/PaddedVarAlignedCodecTest.scala
@@ -1,7 +1,6 @@
 package scodec
 package codecs
 
-//import scodec.bits.BitVector
 import scodec.bits.HexStringSyntax
 
 class PaddedVarAlignedCodecTest extends CodecSuite {

--- a/shared/src/test/scala/scodec/codecs/PaddedVarAlignedCodecTest.scala
+++ b/shared/src/test/scala/scodec/codecs/PaddedVarAlignedCodecTest.scala
@@ -1,0 +1,33 @@
+package scodec
+package codecs
+
+//import scodec.bits.BitVector
+import scodec.bits.HexStringSyntax
+
+class PaddedVarAlignedCodecTest extends CodecSuite {
+
+  "paddedVarAlignedCodec" should {
+    "roundtrip" in {
+      roundtrip(paddedVarAlignedBytes(uint8, utf8, 4), "ab")
+      roundtrip(paddedVarAlignedBytes(uint8, utf8, 4), "abcde")
+      roundtrip(paddedVarAlignedBytes(uint16, ascii, 8), "a")
+    }
+
+    "pad to the correct length" in {
+      paddedVarAlignedBytes(uint8, utf8, 4).encode("a").require shouldBe hex"0x0161000000".toBitVector 
+      paddedVarAlignedBytes(uint8, utf8, 4).encode("aaa").require shouldBe hex"0x0361616100".toBitVector 
+      paddedVarAlignedBytes(uint8, utf8, 4).encode("aaaa").require shouldBe hex"0x461616161".toBitVector
+    }
+
+    "pad on a multiplier" in {
+      paddedVarAlignedBytes(uint8, utf8, 3).encode("aaa").require shouldBe hex"0x03616161".toBitVector 
+      paddedVarAlignedBytes(uint8, utf8, 3).encode("aaaa").require shouldBe hex"0x04616161610000".toBitVector
+    }
+   
+    "ignore padded" in {
+      paddedVarAlignedBytes(uint8, utf8, 4).decode(hex"0x0161000000".toBitVector).require.value shouldBe "a" 
+      paddedVarAlignedBytes(uint8, utf8, 4).decode(hex"0x0361616100".toBitVector).require.value shouldBe "aaa" 
+
+    }
+  }
+}


### PR DESCRIPTION
Some binary protocols have variable sized payloads, but still need you to be 'aligned' on a multiplier (like 32 bits).  This codec helps get variable sized codec padded to the right length. 