### PR TITLE
use Iterable instead of GenTraversable

### DIFF
--- a/testkit/shared/src/main/scala/scodec/CodecSuite.scala
+++ b/testkit/shared/src/main/scala/scodec/CodecSuite.scala
@@ -1,6 +1,5 @@
 package scodec
 
-import scala.collection.GenTraversable
 import scala.concurrent.duration._
 
 import shapeless.Lazy
@@ -30,7 +29,7 @@ abstract class CodecSuite extends WordSpec with Matchers with GeneratorDrivenPro
     ()
   }
 
-  protected def roundtripAll[A](codec: Codec[A], as: GenTraversable[A]): Unit = {
+  protected def roundtripAll[A](codec: Codec[A], as: collection.Iterable[A]): Unit = {
     as foreach { a => roundtrip(codec, a) }
   }
 


### PR DESCRIPTION
deprecated since Scala 2.13.0-M4

https://github.com/scala/scala/blob/v2.13.0-M4/src/library/scala/collection/package.scala#L23-L26