### PR TITLE
Added Err.Composite for choice codecs

### DIFF
--- a/shared/src/main/scala/scodec/Err.scala
+++ b/shared/src/main/scala/scodec/Err.scala
@@ -1,5 +1,7 @@
 package scodec
 
+import scala.reflect.ClassTag
+
 /**
  * Describes an error.
  *
@@ -50,6 +52,14 @@ object Err {
     def pushContext(ctx: String) = copy(context = ctx :: context)
   }
 
+  final case class Composite(errs: List[Err], context: List[String]) extends Err {
+    def this(errs: List[Err]) = this(errs, Nil)
+    def message: String = errs.map(_.message).mkString("composite errors (", ",", ")")
+    def push(err: Err) = copy(errs = err :: errs)
+    def pushContext(ctx: String): Err = copy(context = ctx :: context)
+  }
+
   def apply(message: String): Err = new General(message)
+  def apply(errs: List[Err]): Err = new Composite(errs)
   def insufficientBits(needed: Long, have: Long): Err = new InsufficientBits(needed, have)
 }

--- a/shared/src/main/scala/scodec/Err.scala
+++ b/shared/src/main/scala/scodec/Err.scala
@@ -1,7 +1,5 @@
 package scodec
 
-import scala.reflect.ClassTag
-
 /**
  * Describes an error.
  *


### PR DESCRIPTION
In a streaming context, the typical usage involves accumulating bits and applying a codec until an error other than `Err.InsufficientBits` is encountered. This works fine unless the codec is a [choice](https://github.com/scodec/scodec/blob/e5afd2a5d95d5a110679969384dd3fa75b830f7b/shared/src/main/scala/scodec/codecs/package.scala#L1223) codec, in which case the error returned is the one from the choice applied last.

This PR introduces a composite error type, `Err.Composite`, that retains all errors for choice codecs.
This would enable streaming applications to suspend the decode operation correctly without depending on the order of choices applied.

### Usage (in a streaming context):
```scala

def decodeAccumulate[F[_], A](
  decoder: Decoder[A])(
  bits: BitVector,
  acc: List[A],
  suspend: Err => Boolean)(implicit F: Sync[F]): F[DecodeResult[List[A]]] = 
  decoder.decode(bits) match {
    case Attempt.Failure(e) =>
      if (suspend(e)) F.pure(DecodeResult(acc.reverse, bits)) else F.raiseError(DecodeFailed(bits, e))
    case Attempt.Successful(DecodeResult(a, r)) =>
      if (r.isEmpty) F.pure(DecodeResult((a :: acc).reverse, r))
      else decodeAccumulate(decoder)(r, a :: acc, suspend)
}

def needMoreBits: Err => Boolean = {
  case _: Err.InsufficientBits => true
  case e: Err.Composite => e.errs.exists(needMoreBits)
  case _ => false
}

implicit class DecoderFs2Ops[A](val self: Decoder[A]) extends AnyVal {

  def reader[F[_]](suspend: Err => Boolean = needMoreBits)(
    implicit F: Sync[F]): Pipe[F, ByteVector, A] =
    _.evalScan[DecodeResult[List[A]]](DecodeResult(Nil, BitVector.empty)) {
      case (acc, next) => decodeAccumulate(self)(acc.remainder.bytes.bits ++ next.bits, Nil, suspend)
    }
    .flatMap(result => Stream(result.value: _*))
}

```