### PR TITLE
Added 'terminatedBy' combinator

### DIFF
--- a/shared/src/main/scala/scodec/Err.scala
+++ b/shared/src/main/scala/scodec/Err.scala
@@ -60,4 +60,10 @@ object Err {
   def apply(message: String): Err = new General(message)
   def apply(errs: List[Err]): Err = new Composite(errs)
   def insufficientBits(needed: Long, have: Long): Err = new InsufficientBits(needed, have)
+
+  def needMoreBits: Err => Boolean = {
+    case _: InsufficientBits => true
+    case c: Composite => c.errs.exists(needMoreBits)
+    case _ => false
+  }
 }

--- a/shared/src/main/scala/scodec/codecs/TerminatedByCodec.scala
+++ b/shared/src/main/scala/scodec/codecs/TerminatedByCodec.scala
@@ -1,0 +1,34 @@
+package scodec
+package codecs
+
+import scodec.bits.{BitVector, ByteVector}
+
+final class TerminatedByCodec[A](codec: Codec[A], etx: ByteVector, retry: Err => Boolean) extends Codec[A] {
+
+  // fails with insufficient bits with "best guess" for required bits
+  private[this] def loop(bits: BitVector, from: Long): Attempt[DecodeResult[A]] =
+    if (bits.size < from)
+      Attempt.failure(Err.insufficientBits(bits.size + etx.bits.size, bits.size))
+    else
+      bits.bytes.indexOfSlice(etx, from) match {
+        case -1 =>
+          Attempt.failure(Err.insufficientBits(bits.size + etx.bits.size, bits.size))
+        case i =>
+          bits.bytes.splitAt(i) match {
+            case (b1, b2) =>
+              codec.decode(b1.bits)
+                .map(_.mapRemainder(_ ++ b2.drop(etx.size).bits))
+                .recoverWith {
+                  case e if retry(e) => loop(bits, i + 1)
+                }
+          }
+      }
+
+  def decode(bits: BitVector): Attempt[DecodeResult[A]] = loop(bits, 0)
+
+  def encode(value: A): Attempt[BitVector] = codec.encode(value).map(_ ++ etx.bits)
+
+  def sizeBound: SizeBound = codec.sizeBound + SizeBound.exact(etx.bits.size)
+
+  override def toString: String = s"$codec\\${etx.toHex}"
+}

--- a/unitTests/src/test/scala/scodec/codecs/TerminatedByCodecTest.scala
+++ b/unitTests/src/test/scala/scodec/codecs/TerminatedByCodecTest.scala
@@ -1,0 +1,33 @@
+package scodec
+package codecs
+
+import java.nio.CharBuffer
+import java.nio.charset.{Charset, StandardCharsets}
+
+import scodec.bits._
+
+class TerminatedByCodecTest extends CodecSuite {
+
+  implicit def charset: Charset = StandardCharsets.US_ASCII
+  implicit def char2ByteVector(c: Char)(implicit C: Charset): ByteVector = ByteVector(C.encode(CharBuffer.wrap(Array(c))))
+  implicit def string2ByteVector(s: String)(implicit C: Charset): ByteVector = ByteVector(C.encode(s))
+
+  "terminatedBy codec" should {
+    "roundtrip" in {
+      roundtripAll(ascii \ hex"23", Seq("", "frame", "f r a m e"))
+    }
+  }
+
+  "terminatedBy codec" should {
+    "roundtrip when payload contains terminal character" in {
+      roundtripAll(constant(' ') ~> (constant('[') ~> ascii \ ']') \ ' ', Seq(" ", "frame", "f r a m e"))
+    }
+  }
+
+  "terminatedBy codec" should {
+    "roundtrip when payload contains terminal string" in {
+      implicit def charset: Charset = StandardCharsets.US_ASCII
+      roundtripAll(constant(' ') ~> (constant('[') ~> ascii \ "]") \ " ", Seq(" ", "frame", "f r a m e"))
+    }
+  }
+}


### PR DESCRIPTION
Added `terminatedBy` combinator with alias `\`.

This is particularly useful for text based protocols where the frame size is not encoded.

### Example
```scala
  implicit def charset: Charset = StandardCharsets.US_ASCII
  implicit def char2ByteVector(c: Char)(implicit C: Charset): ByteVector = ByteVector(C.encode(CharBuffer.wrap(Array(c))))

  // decodes text enclosed within spaces where the frame is enclosed within square brackets
  // NOTE the text within the square brackets can contain spaces
  constant(' ') ~> (constant('[') ~> ascii \ ']') \ ' '
```
The decode operation is repeatedly applied for the next occurrence of the terminal character. This retry can be controlled using the `retry` parameter that defaults to `Err.needMoreBits`.

```scala
  def needMoreBits: Err => Boolean = {
    case _: InsufficientBits => true
    case c: Composite => c.errs.exists(needMoreBits)
    case _ => false
  }
```
This method is useful elsewhere, especially in a [streaming context](https://github.com/scodec/scodec/pull/116).
