### PR TITLE
Updates to compile under scala.js 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
 language: scala
 
 scala:
-  - 2.11.12
   - 2.12.10
   - 2.13.1
 
@@ -19,6 +18,8 @@ script:
   - node -v
   - sbt ++$TRAVIS_SCALA_VERSION "project coreJVM" test mimaReportBinaryIssues
   - sbt ++$TRAVIS_SCALA_VERSION "project testkitJVM" test mimaReportBinaryIssues
+  - sbt ++$TRAVIS_SCALA_VERSION "project coreJS" test
+  - sbt ++$TRAVIS_SCALA_VERSION "project testkitJS" test
 
   # Tricks to avoid unnecessary cache updates
   - find $HOME/.sbt -name "*.lock" -exec rm {} +

--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       baseDirectory.value / "../shared/src/main" / dir
     },
     libraryDependencies ++= Seq(
-      "org.scodec" %%% "scodec-bits" % "1.1.12",
+      "org.scodec" %%% "scodec-bits" % "1.1.14",
       "com.chuusai" %%% "shapeless" % "2.3.3"
     ),
     buildInfoPackage := "scodec",
@@ -150,8 +150,8 @@ lazy val testkit = crossProject(JVMPlatform, JSPlatform)
     name := "scodec-testkit",
     libraryDependencies ++= Seq(
       "org.scalacheck" %%% "scalacheck" % "1.14.3",
-      "org.scalatest" %%% "scalatest" % "3.1.0",
-      "org.scalatestplus" %%% "scalacheck-1-14" % "3.1.0.1"
+      "org.scalatest" %%% "scalatest" % "3.1.1",
+      "org.scalatestplus" %%% "scalacheck-1-14" % "3.1.1.1"
     )
   )
   .dependsOn(core % "compile->compile")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=1.3.7
+sbt.version=1.3.8
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "Sonatype Public".at("https://oss.sonatype.org/content/groups/public/")
 
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.32")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 

--- a/testkit/shared/src/main/scala/scodec/CodecSuite.scala
+++ b/testkit/shared/src/main/scala/scodec/CodecSuite.scala
@@ -4,7 +4,7 @@ import scala.concurrent.duration._
 
 import org.scalacheck.{Arbitrary, Gen}
 import Arbitrary.arbitrary
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 

--- a/unitTests/src/test/scala/scodec/SizeBoundTest.scala
+++ b/unitTests/src/test/scala/scodec/SizeBoundTest.scala
@@ -1,6 +1,6 @@
 package scodec
 
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class SizeBoundTest extends AnyWordSpec with Matchers {


### PR DESCRIPTION
This update should let scodec to be published on scala.js 1.0
I'm not sure how releases are made, It would be nice to publish to 0.6.32 and 1.0 for a while
It includes some library updates across the board