### PR TITLE
Remove MaxPermSize from .sbtopts as its no longer supported since JKD…

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,4 +1,3 @@
 -J-Xms2048m
 -J-Xmx2048m
--J-XX:MaxPermSize=512m
 -J-XX:ReservedCodeCacheSize=256m


### PR DESCRIPTION
MaxPermSize has been removed from the JDK since 1.8.  SBT reads the .sbtopts and this causes SBT to issue the following warnings when launched from the scodec repo:
```
Java HotSpot(TM) 64-Bit Server VM warning: Ignoring option MaxPermSize; support was removed in 8.0
Java HotSpot(TM) 64-Bit Server VM warning: Ignoring option MaxPermSize; support was removed in 8.0
[info] welcome to sbt 1.3.12 (Oracle Corporation Java 14)
```