### PR TITLE
Fix [list|vector]ofN codecs chunk behavior.

### DIFF
--- a/shared/src/main/scala/scodec/codecs/package.scala
+++ b/shared/src/main/scala/scodec/codecs/package.scala
@@ -1327,12 +1327,10 @@ package object codecs {
         {
           case (cnt, xs) =>
             if (xs.size == cnt) Attempt.successful(xs)
-            else
-              Attempt.failure(
-                Err(
-                  s"Insufficient number of elements: decoded ${xs.size} but should have decoded $cnt"
-                )
-              )
+            else {
+              val valueBits = valueCodec.sizeBound.exact.getOrElse(valueCodec.sizeBound.lowerBound)
+              Attempt.failure(Err.insufficientBits(cnt * valueBits, xs.size * valueBits))
+            }
         },
         xs => (xs.size, xs)
       )
@@ -1428,12 +1426,10 @@ package object codecs {
         {
           case (cnt, xs) =>
             if (xs.size == cnt) Attempt.successful(xs)
-            else
-              Attempt.failure(
-                Err(
-                  s"Insufficient number of elements: decoded ${xs.size} but should have decoded $cnt"
-                )
-              )
+            else {
+              val valueBits = valueCodec.sizeBound.exact.getOrElse(valueCodec.sizeBound.lowerBound)
+              Attempt.failure(Err.insufficientBits(cnt * valueBits, xs.size * valueBits))
+            }
         },
         xs => (xs.size, xs)
       )

--- a/unitTests/src/test/scala/scodec/codecs/ListCodecTest.scala
+++ b/unitTests/src/test/scala/scodec/codecs/ListCodecTest.scala
@@ -28,7 +28,7 @@ class ListCodecTest extends CodecSuite {
   test("fails decoding if < N elements decoded") {
     val codec = listOfN(provide(10), uint8)
     assertEquals(codec.decode(BitVector.low(8 * 5)), Attempt.failure(
-      Err("Insufficient number of elements: decoded 5 but should have decoded 10")
+      Err.insufficientBits(80, 40)
     ))
   }
 }

--- a/unitTests/src/test/scala/scodec/codecs/VectorCodecTest.scala
+++ b/unitTests/src/test/scala/scodec/codecs/VectorCodecTest.scala
@@ -73,7 +73,7 @@ class VectorCodecTest extends CodecSuite {
   test("fails decoding if < N elements decoded") {
     val codec = vectorOfN(provide(10), uint8)
     assertEquals(codec.decode(BitVector.low(8 * 5)), Attempt.failure(
-      Err("Insufficient number of elements: decoded 5 but should have decoded 10")
+      Err.insufficientBits(80, 40)
     ))
   }
 }


### PR DESCRIPTION
Inspired by scodec/scodec-stream#58. I've also come up against ths same issue when decoding large messages using scodec-stream. The changes in this PR seem to solve the issue in my local project.