### PR TITLE
Change varlong to return a failure instead of throwing when encoding a negative value

### DIFF
--- a/unitTests/src/test/scala/scodec/codecs/DiscriminatorCodecTest.scala
+++ b/unitTests/src/test/scala/scodec/codecs/DiscriminatorCodecTest.scala
@@ -49,7 +49,7 @@ class DiscriminatorCodecTest extends CodecSuite:
 
   test("support building a codec using partial functions and subtyping") {
     val codec =
-      discriminated[Any]
+      discriminated[Matchable]
         .by(uint8)
         .subcaseP[Int](0) { case i: Int => i }(int32)
         .subcaseP[Boolean](1) { case b: Boolean => b }(bool)
@@ -62,7 +62,7 @@ class DiscriminatorCodecTest extends CodecSuite:
 
   test("support building a codec using A => Option[B] and subtyping") {
     val codec =
-      discriminated[Any]
+      discriminated[Matchable]
         .by(uint8)
         .subcaseO[Int](0) { v =>
           v match { case i: Int => Some(i); case _ => None }

--- a/unitTests/src/test/scala/scodec/codecs/RecoverCodecTest.scala
+++ b/unitTests/src/test/scala/scodec/codecs/RecoverCodecTest.scala
@@ -39,10 +39,11 @@ class RecoverCodecTest extends CodecSuite:
   property("recover - always code a value for true value") {
     forAll { (i: Int) =>
       val codec = recover(constant(BitVector.fromInt(i)))
-      val Attempt.Successful(DecodeResult(b2, rest)) = for {
-        bits <- codec.encode(true)
-        result <- codec.decode(bits)
-      } yield result
+      val Attempt.Successful(DecodeResult(b2, rest)) =
+        (for
+          bits <- codec.encode(true)
+          result <- codec.decode(bits)
+        yield result): @unchecked
       assert(rest.isEmpty)
       assert(b2)
     }
@@ -51,10 +52,11 @@ class RecoverCodecTest extends CodecSuite:
   property("recover - always code an empty vector for false value") {
     forAll { (i: Int) =>
       val codec = recover(constant(BitVector.fromInt(i)))
-      val Attempt.Successful(DecodeResult(b2, rest)) = for {
-        bits <- codec.encode(false)
-        result <- codec.decode(bits)
-      } yield result
+      val Attempt.Successful(DecodeResult(b2, rest)) = 
+        (for
+          bits <- codec.encode(false)
+          result <- codec.decode(bits)
+        yield result): @unchecked
       assert(rest.isEmpty)
       assert(!b2)
     }
@@ -82,10 +84,11 @@ class RecoverCodecTest extends CodecSuite:
   property("lookahead - always code a value for true value") {
     forAll { (i: Int) =>
       val codec = lookahead(constant(BitVector.fromInt(i)))
-      val Attempt.Successful((encoded, DecodeResult(b2, rest))) = for {
-        bits <- codec.encode(true)
-        result <- codec.decode(bits)
-      } yield (bits, result)
+      val Attempt.Successful((encoded, DecodeResult(b2, rest))) = 
+        (for
+          bits <- codec.encode(true)
+          result <- codec.decode(bits)
+        yield (bits, result)): @unchecked
       assertEquals(rest, encoded)
       assert(b2)
     }
@@ -94,10 +97,11 @@ class RecoverCodecTest extends CodecSuite:
   property("lookahead - always code an empty vector for false value") {
     forAll { (i: Int) =>
       val codec = lookahead(constant(BitVector.fromInt(i)))
-      val Attempt.Successful(DecodeResult(b2, rest)) = for {
-        bits <- codec.encode(false)
-        result <- codec.decode(bits)
-      } yield result
+      val Attempt.Successful(DecodeResult(b2, rest)) = 
+        (for
+          bits <- codec.encode(false)
+          result <- codec.decode(bits)
+        yield result): @unchecked
       assert(rest.isEmpty)
       assert(!b2)
     }

--- a/unitTests/src/test/scala/scodec/codecs/VarLongCodecTest.scala
+++ b/unitTests/src/test/scala/scodec/codecs/VarLongCodecTest.scala
@@ -61,3 +61,5 @@ class VarLongCodecTest extends CodecSuite:
   test("vlongL - use 7 bytes for longs <= 49 bits")(check(4398046511104L, 562949953421311L, 7)(vlongL))
   test("vlongL - use 8 bytes for longs <= 56 bits")(check(562949953421312L, 72057594037927935L, 8)(vlongL))
   test("vlongL - use 9 bytes for longs <= 63 bits")(check(72057594037927936L, Long.MaxValue, 9)(vlongL))
+
+  test("vlong - negative")(assert(vlong.encode(-1).isFailure))


### PR DESCRIPTION
Fixes #344