### PR TITLE
Use `case Any =>` instead of `case ? =>` in match type

### DIFF
--- a/shared/src/main/scala/scodec/DropUnits.scala
+++ b/shared/src/main/scala/scodec/DropUnits.scala
@@ -37,7 +37,7 @@ type DropUnits[A <: Tuple] <: Tuple = A match
   case hd *: tl =>
     hd match
       case Unit => DropUnits[tl]
-      case ?    => hd *: DropUnits[tl]
+      case Any  => hd *: DropUnits[tl]
   case EmptyTuple => EmptyTuple
 
 object DropUnits:


### PR DESCRIPTION
We broke scodec in Dotty's community build with https://github.com/lampepfl/dotty/pull/12261 (this was the only usage of the unintended syntax I could find). This PR backports the diff.