### PR TITLE
More efficient long conversion for negative ints in `VarIntCodec`

### DIFF
--- a/shared/src/main/scala/scodec/codecs/VarIntCodec.scala
+++ b/shared/src/main/scala/scodec/codecs/VarIntCodec.scala
@@ -48,9 +48,6 @@ private[codecs] final class VarIntCodec(ordering: ByteOrdering) extends Codec[In
   override def toString = "variable-length integer"
 
 private object VarIntCodec:
-  private val NegativeIntSignBit = Int.MaxValue.toLong + 1L
-
   // toLong left-pads with `1` if the int is negative which cannot be encoded by
   // the VarLongCodec. This pads negative ints with `0` instead.
-  private val toPositiveLong = (i: Int) =>
-    if i >= 0 then i.toLong else (i & Int.MaxValue) | NegativeIntSignBit
+  private val toPositiveLong = (i: Int) => if i >= 0 then i.toLong else i & 0x0ffffffffL


### PR DESCRIPTION
Two bitwise operations can be squashed into a single one.

Paranoid extra mode on, here's the bytecode before/after:

### Before

```
public long scodec$codecs$VarIntCodec$$$toPositiveLong(int);
  Code:
     0: iload_1
     1: iconst_0
     2: if_icmplt     8
     5: iload_1
     6: i2l
     7: lreturn
     8: iload_1
     9: ldc           #21                 // int 2147483647
    11: iand
    12: i2l
    13: getstatic     #23                 // Field NegativeIntSignBit:J
    16: lor
    17: lreturn
```

### After
```
public long scodec$codecs$VarIntCodec$$$toPositiveLong(int);
  Code:
     0: iload_1
     1: iconst_0
     2: if_icmplt     8
     5: iload_1
     6: i2l
     7: lreturn
     8: iload_1
     9: i2l
    10: ldc2_w        #29                 // long 4294967295l
    13: land
    14: lreturn
```