### PR TITLE
Fix bounds for `VarIntCodec`/`VarLongCodec`

### DIFF
--- a/shared/src/main/scala/scodec/codecs/VarIntCodec.scala
+++ b/shared/src/main/scala/scodec/codecs/VarIntCodec.scala
@@ -37,7 +37,7 @@ private[codecs] final class VarIntCodec(ordering: ByteOrdering) extends Codec[In
   private val long = new VarLongCodec(ordering).xmap(_.toInt, VarIntCodec.toPositiveLong)
 
   override def sizeBound =
-    SizeBound.bounded(1L, 5L)
+    SizeBound.bounded(8L, 40L)
 
   override def encode(i: Int) =
     long.encode(i)

--- a/shared/src/main/scala/scodec/codecs/VarLongCodec.scala
+++ b/shared/src/main/scala/scodec/codecs/VarLongCodec.scala
@@ -41,7 +41,7 @@ import scala.annotation.tailrec
 private[codecs] final class VarLongCodec(ordering: ByteOrdering) extends Codec[Long]:
   import VarLongCodec.*
 
-  override def sizeBound = SizeBound.bounded(1L, 9L)
+  override def sizeBound = SizeBound.bounded(8L, 72L)
 
   override def encode(i: Long) =
     if i < 0 then Attempt.failure(Err("VarLong cannot encode negative longs"))


### PR DESCRIPTION
Fixes #238

Express them in bits and not bytes, just as it's done in another `Codec[A]`s.