### PR TITLE
Support negative values for `VarLongCodec`

### DIFF
--- a/unitTests/shared/src/test/scala/scodec/codecs/VarLongCodecTest.scala
+++ b/unitTests/shared/src/test/scala/scodec/codecs/VarLongCodecTest.scala
@@ -40,7 +40,7 @@ class VarLongCodecTest extends CodecSuite:
       assertEquals(codec.encode(n).map(_.bytes.size), Attempt.successful(size))
     }
 
-  test("vlong - roundtrip")(forAll(Gen.choose(0L, Long.MaxValue))(roundtrip(vlong, _)))
+  test("vlong - roundtrip")(forAll(Gen.choose(Long.MinValue, Long.MaxValue))(roundtrip(vlong, _)))
   test("vlong - use 1 byte for longs <= 7 bits")(check(0L, 127L, 1)(vlong))
   test("vlong - use 2 bytes for longs <= 14 bits")(check(128L, 16383L, 2)(vlong))
   test("vlong - use 3 bytes for longs <= 21 bits")(check(16384L, 2097151L, 3)(vlong))
@@ -56,8 +56,9 @@ class VarLongCodecTest extends CodecSuite:
   test("vlong - use 9 bytes for longs <= 63 bits")(
     check(72057594037927936L, Long.MaxValue, 9)(vlong)
   )
+  test("vlong - use 10 bytes for negative longs")(check(Long.MinValue, -1, 10)(vlong))
 
-  test("vlongL - roundtrip")(forAll(Gen.choose(0L, Long.MaxValue))(roundtrip(vlongL, _)))
+  test("vlongL - roundtrip")(forAll(Gen.choose(Long.MinValue, Long.MaxValue))(roundtrip(vlongL, _)))
   test("vlongL - use 1 byte for longs <= 7 bits")(check(0L, 127L, 1)(vlongL))
   test("vlongL - use 2 bytes for longs <= 14 bits")(check(128L, 16383L, 2)(vlongL))
   test("vlongL - use 3 bytes for longs <= 21 bits")(check(16384L, 2097151L, 3)(vlongL))
@@ -73,5 +74,4 @@ class VarLongCodecTest extends CodecSuite:
   test("vlongL - use 9 bytes for longs <= 63 bits")(
     check(72057594037927936L, Long.MaxValue, 9)(vlongL)
   )
-
-  test("vlong - negative")(assert(vlong.encode(-1).isFailure))
+  test("vlong - use 10 bytes for negative longs")(check(Long.MinValue, -1, 10)(vlongL))


### PR DESCRIPTION
These days I'm revisiting all the stuff around `VarIntCodec`/`VarLongCodec` because I plan to add support for signed zig-zag encoding for a side project I'm working on (a pure Scala Kafka protocol implementation).

It draw my attention though that `VarLongCodec` doesn't support negative values. According to the original [PR](https://github.com/scodec/scodec/pull/64) :

>negative longs aren't even supported in the first place.

But I don't see a reason for not supporting them 🤔.  In fact, the implementation used in Kafka codebase supports it out-of-the-box and I can't see any argument against it in the Wikipedia link from the original PR.

Please, let me know if I'm missing something 🙏🏽 