### PR TITLE
Signed zig-zag codecs for variable-length ints/longs

### DIFF
--- a/shared/src/main/scala/scodec/codecs/VarIntZigZagCodec.scala
+++ b/shared/src/main/scala/scodec/codecs/VarIntZigZagCodec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2013, Scodec
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package scodec
+package codecs
+
+import scodec.bits.{BitVector, ByteOrdering}
+
+/** Zig-zag encoding for negative numbers (defined by Google Protocol Buffers but also used in other protocols like Kafka).
+  *
+  * @see https://en.wikipedia.org/wiki/Variable-length_quantity#Zigzag_encoding
+  * @see https://developers.google.com/protocol-buffers/docs/encoding#signed-ints
+  */
+private[codecs] final class VarIntZigZagCodec(ordering: ByteOrdering) extends Codec[Int]:
+  import VarIntZigZagCodec.*
+
+  private val codec = new VarIntCodec(ordering).xmap(zigZagDecode, zigZagEncode)
+
+  override val sizeBound =
+    codec.sizeBound
+
+  override def encode(i: Int) =
+    codec.encode(i)
+
+  override def decode(buffer: BitVector) =
+    codec.decode(buffer)
+
+  override def toString = "variable-length zig-zag signed integer"
+
+private object VarIntZigZagCodec:
+  private val zigZagEncode = (value: Int) => (value << 1) ^ (value >> 31)
+  private val zigZagDecode = (value: Int) => (value >>> 1) ^ -(value & 1)

--- a/shared/src/main/scala/scodec/codecs/VarLongZigZagCodec.scala
+++ b/shared/src/main/scala/scodec/codecs/VarLongZigZagCodec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2013, Scodec
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package scodec
+package codecs
+
+import scodec.bits.{BitVector, ByteOrdering}
+
+/** Zig-zag encoding for negative numbers (defined by Google Protocol Buffers but also used in other protocols like Kafka).
+  *
+  * @see https://en.wikipedia.org/wiki/Variable-length_quantity#Zigzag_encoding
+  * @see https://developers.google.com/protocol-buffers/docs/encoding#signed-ints
+  */
+private[codecs] final class VarLongZigZagCodec(ordering: ByteOrdering) extends Codec[Long]:
+  import VarLongZigZagCodec.*
+
+  private val codec = new VarLongCodec(ordering).xmap(zigZagDecode, zigZagEncode)
+
+  override val sizeBound =
+    codec.sizeBound
+
+  override def encode(i: Long) =
+    codec.encode(i)
+
+  override def decode(buffer: BitVector) =
+    codec.decode(buffer)
+
+  override def toString = "variable-length zig-zag signed long"
+
+private object VarLongZigZagCodec:
+  private val zigZagEncode = (value: Long) => (value << 1) ^ (value >> 63)
+  private val zigZagDecode = (value: Long) => (value >>> 1) ^ -(value & 1)

--- a/shared/src/main/scala/scodec/codecs/codecs.scala
+++ b/shared/src/main/scala/scodec/codecs/codecs.scala
@@ -276,6 +276,30 @@ val vpbcd: Codec[Long] = VarPackedDecimalCodec
   */
 val vlongL: Codec[Long] = new VarLongCodec(ByteOrdering.LittleEndian)
 
+/** Codec for variable-length big-endian integers with zig-zag encoding for signed values.
+  * Encoding requires between 1 and 5 bytes, depending on the value.
+  * Smaller ints require less bytes.
+  */
+val zint: Codec[Int] = new VarIntZigZagCodec(ByteOrdering.BigEndian)
+
+/** Codec for variable-length little-endian integers with zig-zag encoding for signed values.
+  * Encoding requires between 1 and 5 bytes, depending on the value.
+  * Smaller ints require less bytes.
+  */
+val zintL: Codec[Int] = new VarIntZigZagCodec(ByteOrdering.LittleEndian)
+
+/** Codec for variable-length big-endian longs with zig-zag encoding for signed values.
+  * Encoding requires between 1 and 10 bytes, depending on the value.
+  * Smaller longs require less bytes.
+  */
+val zlong: Codec[Long] = new VarLongZigZagCodec(ByteOrdering.BigEndian)
+
+/** Codec for variable-length little-endian longs with zig-zag encoding for signed values.
+  * Encoding requires between 1 and 10 bytes, depending on the value.
+  * Smaller longs require less bytes.
+  */
+val zlongL: Codec[Long] = new VarLongZigZagCodec(ByteOrdering.LittleEndian)
+
 /** Codec for n-bit 2s complement bytes.
   * @param size number of bits (must be 0 < size <= 8)
   */

--- a/unitTests/shared/src/test/scala/scodec/codecs/VarIntZigZagCodecTest.scala
+++ b/unitTests/shared/src/test/scala/scodec/codecs/VarIntZigZagCodecTest.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2013, Scodec
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package scodec
+package codecs
+
+import org.scalacheck.Gen
+import org.scalacheck.Prop.forAll
+import scodec.bits.{bin, hex}
+
+class VarIntZigZagCodecTest extends CodecSuite:
+
+  def check(low: Int, high: Int, size: Long)(codec: Codec[Int]) =
+    forAll(Gen.choose(low, high)) { n =>
+      assertEquals(codec.encode(n).map(_.bytes.size), Attempt.successful(size))
+    }
+
+  test("zint - roundtrip")(forAll(Gen.choose(Int.MinValue, Int.MaxValue))(roundtrip(zint, _)))
+  test("zint - use 1 byte for abs ints <= 6 bits")(
+    check(-64, -1, 1)(zint) && check(0, 63, 1)(zint)
+  )
+  test("zint - use 2 bytes for abs ints <= 13 bits")(
+    check(-8192, -65, 2)(zint) && check(64, 8191, 2)(zint)
+  )
+  test("zint - use 3 bytes for abs ints <= 20 bits")(
+    check(-1048576, -8193, 3)(zint) && check(8192, 1048575, 3)(zint)
+  )
+  test("zint - use 4 bytes for abs ints <= 27 bits")(
+    check(-134217728, -1048577, 4)(zint) && check(1048576, 134217727, 4)(zint)
+  )
+  test("zint - use 5 bytes for abs ints <= 31 bits")(
+    check(Int.MinValue, -134217729, 5)(zint) && check(134217728, Int.MaxValue, 5)(zint)
+  )
+
+  test("zintL - roundtrip")(forAll(Gen.choose(Int.MinValue, Int.MaxValue))(roundtrip(zintL, _)))
+  test("zintL - use 1 byte for abs ints <= 6 bits")(
+    check(-64, -1, 1)(zintL) && check(0, 63, 1)(zintL)
+  )
+  test("zintL - use 2 bytes for abs ints <= 13 bits")(
+    check(-8192, -65, 2)(zintL) && check(64, 8191, 2)(zintL)
+  )
+  test("zintL - use 3 bytes for abs ints <= 20 bits")(
+    check(-1048576, -8193, 3)(zintL) && check(8192, 1048575, 3)(zintL)
+  )
+  test("zintL - use 4 bytes for abs ints <= 27 bits")(
+    check(-134217728, -1048577, 4)(zintL) && check(1048576, 134217727, 4)(zintL)
+  )
+  test("zintL - use 5 bytes for abs ints <= 31 bits")(
+    check(Int.MinValue, -134217729, 5)(zintL) && check(134217728, Int.MaxValue, 5)(zintL)
+  )

--- a/unitTests/shared/src/test/scala/scodec/codecs/VarLongZigZagCodecTest.scala
+++ b/unitTests/shared/src/test/scala/scodec/codecs/VarLongZigZagCodecTest.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2013, Scodec
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package scodec
+package codecs
+
+import org.scalacheck.Gen
+import org.scalacheck.Prop.forAll
+import scodec.bits.{bin, hex}
+
+class VarLongZigZagCodecTest extends CodecSuite:
+
+  def check(low: Long, high: Long, size: Long)(codec: Codec[Long]) =
+    forAll(Gen.choose(low, high)) { n =>
+      assertEquals(codec.encode(n).map(_.bytes.size), Attempt.successful(size))
+    }
+
+  test("zlong - roundtrip")(forAll(Gen.choose(Long.MinValue, Long.MaxValue))(roundtrip(zlong, _)))
+  test("zlong - use 1 byte for abs longs <= 6 bits")(
+    check(-64L, -1L, 1)(zlong) && check(0L, 63L, 1)(zlong)
+  )
+  test("zlong - use 2 bytes for abs longs <= 13 bits")(
+    check(-8192L, -65L, 2)(zlong) && check(64L, 8191L, 2)(zlong)
+  )
+  test("zlong - use 3 bytes for abs longs <= 20 bits")(
+    check(-1048576L, -8193L, 3)(zlong) && check(8192L, 1048575L, 3)(zlong)
+  )
+  test("zlong - use 4 bytes for abs longs <= 27 bits")(
+    check(-134217728L, -1048577L, 4)(zlong) && check(1048576L, 134217727L, 4)(zlong)
+  )
+  test("zlong - use 5 bytes for abs longs <= 34 bits")(
+    check(-17179869184L, -134217729L, 5)(zlong) && check(134217728L, 17179869183L, 5)(zlong)
+  )
+  test("zlong - use 6 bytes for abs longs <= 41 bits")(
+    check(-2199023255552L, -17179869185L, 6)(zlong) && check(17179869184L, 2199023255551L, 6)(zlong)
+  )
+  test("zlong - use 7 bytes for abs longs <= 48 bits")(
+    check(-281474976710656L, -2199023255553L, 7)(zlong) &&
+      check(2199023255552L, 281474976710655L, 7)(zlong)
+  )
+  test("zlong - use 8 bytes for abs longs <= 55 bits")(
+    check(-36028797018963968L, -281474976710657L, 8)(zlong) &&
+      check(281474976710656L, 36028797018963967L, 8)(zlong)
+  )
+  test("zlong - use 9 bytes for abs longs <= 62 bits")(
+    check(-4611686018427387904L, -36028797018963969L, 9)(zlong) &&
+      check(36028797018963968L, 4611686018427387903L, 9)(zlong)
+  )
+  test("zlong - use 10 bytes for abs longs <= 63 bits")(
+    check(Long.MinValue, -4611686018427387905L, 10)(zlong) &&
+      check(4611686018427387904L, Long.MaxValue, 10)(zlong)
+  )
+
+  test("zlongL - roundtrip")(forAll(Gen.choose(Long.MinValue, Long.MaxValue))(roundtrip(zlongL, _)))
+  test("zlongL - use 1 byte for abs longs <= 6 bits")(
+    check(-64L, -1L, 1)(zlongL) && check(0L, 63L, 1)(zlongL)
+  )
+  test("zlongL - use 2 bytes for abs longs <= 13 bits")(
+    check(-8192L, -65L, 2)(zlongL) && check(64L, 8191L, 2)(zlongL)
+  )
+  test("zlongL - use 3 bytes for abs longs <= 20 bits")(
+    check(-1048576L, -8193L, 3)(zlongL) && check(8192L, 1048575L, 3)(zlongL)
+  )
+  test("zlongL - use 4 bytes for abs longs <= 27 bits")(
+    check(-134217728L, -1048577L, 4)(zlongL) && check(1048576L, 134217727L, 4)(zlongL)
+  )
+  test("zlongL - use 5 bytes for abs longs <= 34 bits")(
+    check(-17179869184L, -134217729L, 5)(zlongL) && check(134217728L, 17179869183L, 5)(zlongL)
+  )
+  test("zlongL - use 6 bytes for abs longs <= 41 bits")(
+    check(-2199023255552L, -17179869185L, 6)(zlongL) &&
+      check(17179869184L, 2199023255551L, 6)(zlongL)
+  )
+  test("zlongL - use 7 bytes for abs longs <= 48 bits")(
+    check(-281474976710656L, -2199023255553L, 7)(zlongL) &&
+      check(2199023255552L, 281474976710655L, 7)(zlongL)
+  )
+  test("zlongL - use 8 bytes for abs longs <= 55 bits")(
+    check(-36028797018963968L, -281474976710657L, 8)(zlongL) &&
+      check(281474976710656L, 36028797018963967L, 8)(zlongL)
+  )
+  test("zlongL - use 9 bytes for abs longs <= 62 bits")(
+    check(-4611686018427387904L, -36028797018963969L, 9)(zlongL) &&
+      check(36028797018963968L, 4611686018427387903L, 9)(zlongL)
+  )
+  test("zlongL - use 10 bytes for abs longs <= 63 bits")(
+    check(Long.MinValue, -4611686018427387905L, 10)(zlongL) &&
+      check(4611686018427387904L, Long.MaxValue, 10)(zlongL)
+  )


### PR DESCRIPTION
As mentioned in #438 this PR adds missing zig-zag codecs for signed numbers.

I've cherry-picked the commit from #438 (it's absolutely necessary). Just because I'm always uncertain about the implications on merging things, I'll leave it as a draft to avoid the merge. Once #438 is approved/merged, I'll rebase this branch with main to have a clean history.