### PR TITLE
Update to Scala 3.4.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ ThisBuild / tlSonatypeUseLegacyHost := true
 
 ThisBuild / startYear := Some(2013)
 
-ThisBuild / crossScalaVersions := Seq("3.3.1")
+ThisBuild / crossScalaVersions := Seq("3.4.0")
 
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("8"))
 


### PR DESCRIPTION
Don't merge - scodec will stay on Scala 3 LTS series.

Depends on a new patch release of Scala Native with this fix: https://github.com/scala-native/scala-native/issues/3700