### PR TITLE
Re-implement inline operations to avoid creating a new class for each invocation

### DIFF
--- a/shared/src/main/scala/scodec/Codec.scala
+++ b/shared/src/main/scala/scodec/Codec.scala
@@ -424,16 +424,19 @@ object Codec extends EncoderFunctions, DecoderFunctions:
       case s: Mirror.SumOf[A] =>
         inlineImplementations.SumCodec(s, componentCodecs)
 
+  // From https://github.com/scala/scala3/blob/ebbd685cfb02e1935afb9b4fd568643315825c57/docs/_docs/reference/contextual/derivation.md
   private inline def summonCodecInstances[T, Elems <: Tuple]: List[Codec[?]] =
     inline erasedValue[Elems] match
       case _: (elem *: elems) => deriveOrSummonCodec[T, elem] :: summonCodecInstances[T, elems]
       case _: EmptyTuple      => Nil
 
+  // From https://github.com/scala/scala3/blob/ebbd685cfb02e1935afb9b4fd568643315825c57/docs/_docs/reference/contextual/derivation.md
   private inline def deriveOrSummonCodec[T, Elem]: Codec[Elem] =
     inline erasedValue[Elem & Matchable] match
       case _: T => deriveCodecRecursive[T, Elem]
       case _    => summonInline[Codec[Elem]]
 
+  // From https://github.com/scala/scala3/blob/ebbd685cfb02e1935afb9b4fd568643315825c57/docs/_docs/reference/contextual/derivation.md
   private inline def deriveCodecRecursive[T, Elem]: Codec[Elem] =
     inline erasedValue[T & Matchable] match
       case _: Elem => error("infinite recursive derivation")

--- a/unitTests/shared/src/test/scala/scodec/examples/AdtExample.scala
+++ b/unitTests/shared/src/test/scala/scodec/examples/AdtExample.scala
@@ -32,7 +32,6 @@ package scodec
 package examples
 
 import scodec.bits.*
-import codecs.*
 
 class AdtExample extends CodecSuite:
 


### PR DESCRIPTION
@milessabin warned me about this when I first created scodec 2.x but I had never gotten around to fixing it. The Scala 3.3.4 upgrade resulted in warnings on each such inline anonymous class so I finally decided to tackle this. Turns out this approach is more concise than the conceptually more elegant recursive inline definitions.

Before:

```
❯ find unitTests/jvm/target/ -name "*.class" | wc -l
     259

❯ find unitTests/jvm/target/ -name "Derived*.class" | wc -l
      71
```

After:

```
❯ find unitTests/jvm/target/ -name "*.class" | wc -l
     231

❯ find unitTests/jvm/target/ -name "Derived*.class" | wc -l
      53
```

